### PR TITLE
add freeipa to ldap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@
 * [389 Directory Server](http://port389.org) - Developed by Red Hat.
 * [Apache Directory Server](http://directory.apache.org/) - Apache Software Foundation project written in Java.
 * [Fusion Directory](http://www.fusiondirectory.org) - Improve the Management of the services and the company directory based on OpenLDAP.
-* [FreeIPA](http://http://www.freeipa.org/) - FreeIPA security information management solution, can manage LDAP,KRB,DNS, and more
+* [FreeIPA](http://www.freeipa.org/) - security management solution, can manage LDAP,KRB,DNS, sudo, and more
 * [OpenDJ](http://opendj.forgerock.org/) - Fork of OpenDS.
 * [OpenDS](https://opends.java.net/) - Another directory server written in Java.
 * [OpenLDAP](http://openldap.org/) - Developed by the OpenLDAP Project.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@
 * [389 Directory Server](http://port389.org) - Developed by Red Hat.
 * [Apache Directory Server](http://directory.apache.org/) - Apache Software Foundation project written in Java.
 * [Fusion Directory](http://www.fusiondirectory.org) - Improve the Management of the services and the company directory based on OpenLDAP.
-* [FreeIPA](http://http://www.freeipa.org/) - FreeIPA is an integrated security information management solution, can manage LDAP,KRB,DNS, and more
+* [FreeIPA](http://http://www.freeipa.org/) - FreeIPA security information management solution, can manage LDAP,KRB,DNS, and more
 * [OpenDJ](http://opendj.forgerock.org/) - Fork of OpenDS.
 * [OpenDS](https://opends.java.net/) - Another directory server written in Java.
 * [OpenLDAP](http://openldap.org/) - Developed by the OpenLDAP Project.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@
 * [389 Directory Server](http://port389.org) - Developed by Red Hat.
 * [Apache Directory Server](http://directory.apache.org/) - Apache Software Foundation project written in Java.
 * [Fusion Directory](http://www.fusiondirectory.org) - Improve the Management of the services and the company directory based on OpenLDAP.
+* [FreeIPA](http://http://www.freeipa.org/) - FreeIPA is an integrated security information management solution, can manage LDAP,KRB,DNS, and more
 * [OpenDJ](http://opendj.forgerock.org/) - Fork of OpenDS.
 * [OpenDS](https://opends.java.net/) - Another directory server written in Java.
 * [OpenLDAP](http://openldap.org/) - Developed by the OpenLDAP Project.


### PR DESCRIPTION
Integrated security information management solution combining Linux (Fedora), 389 Directory Server, MIT Kerberos, NTP, DNS, Dogtag certificate system, SSSD and others. Consists of a webUI and CLI for administration. Integrates with other utilities such as Puppet, Katello, Pulp for node provisioning and lifecycle management.

FreeIPA is the upstream project behind RedHat Directory.

Might be a bit much for the LDAP section, but I didn't want to add a whole new identity management section with one entry.