### PR TITLE
add more backup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@
 * [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
 * [Elkarbackup](https://github.com/elkarbackup/elkarbackup) - Backup solution based on RSnapshot with a simple web interface
 * [Lsyncd](https://github.com/axkibe/lsyncd) - File Monitor which spawns a process to synchronize the changes (rsync by default).
+* [Obnam](http://obnam.org/) - An easy, secure, snapshots-based backup program with data de-duplication.
+* [Rdiff-backup](http://www.nongnu.org/rdiff-backup/) - An easy A remote incremental backup of all your files.
 * [Rsnapshot](http://www.rsnapshot.org/) - Filesystem Snapshotting Utility.
 * [SafeKeep](http://safekeep.sourceforge.net/) - Centralized pull-based backup using `rdiff-backup`.
 * [Snebu](http://www.snebu.com/) – Snapshot backup with global multi-client deduplication and transparent compression.


### PR DESCRIPTION
 * [obnam](http://obnam.org/) is a backup tool that supports network backups, GPG encryption, data de-duplication (" If the backup repository already contains a particular chunk of data, it will be re-used, even if it was in another file in an older backup generation."). It is snapshot-based and has an easy to use but powerful command line interface. Obnam backup generations can be mounted as a filesystem.
 * ~~[clonezilla](http://clonezilla.org/) - do I need to introduce it - is a disk imaging and cloning tool running as a Live CD/USB. It can be used to move operating systems and other partititons between machines, bare metal or virtual, do full backups of an installed system, and more.~~
 * [rdiff-backup](http://www.nongnu.org/rdiff-backup/) is another well known backup tool. It is fast over a network as it only transmits deltas. It stores the most recent backup as a plain copy of the original directory structure, while reverse diffs to previous versions (including deleted files) are stored in a special subdirectory ("The idea is to combine the best features of a mirror and an incremental backup.")