### PR TITLE
Add cmail to mail server section

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@
 ### MTA (SMTP)
 *Mail Transfer Agents (SMTP servers).*
 
+* [cmail](http://cmail.rocks/) - Mail server suite with SQLite backend.
 * [Exim](http://www.exim.org/) - Message transfer agent (MTA) developed at the University of Cambridge.
 * [Haraka](http://haraka.github.io/) - A high-performance, pluginable SMTP server written in JavaScript.
 * [MailCatcher](http://mailcatcher.me/) - Ruby gem that deploys a simply SMTP MTA gateway that accepts all mail and displays in web interface. Useful for debugging or development.


### PR DESCRIPTION
This adds cmail (http://cmail.rocks/ | https://github.com/cmail-mta/), a mail server suite (SMTP server, SMTP client, POP server, (Planned) IMAP server) to the mail server section. The License is Simplified/2-Clause BSD.

The project is under active development, the main components are already very stable and in productive use by multiple people. It was created with the explicit goals of an easy setup and configuration process, separation of concerns and clear interfaces, making it best suited for people who want to run a mail server of their own, but shun away from the heavy, complex configuration of traditional MTAs. 