### PR TITLE
Add travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md --allow-dupe --allow-redirect


### PR DESCRIPTION
Adds travis configuration to check all the links in README.md.

You will have to go to [travis-ci.org](https://travis-ci.org) and turn on checking there, but this configuration should work for validating links.

Closes #128 