### PR TITLE
Add BorgBackup to backup software

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@
 *Backup software.*
 
   * [Amanda](http://www.amanda.org/) - Client-server model backup tool.
-  * [Attic](https://attic-backup.org) - A deduplicating backup program written in Python.
   * [Bareos](http://www.bareos.org/en/) - A fork of Bacula backup tool.
   * [Backupninja](https://labs.riseup.net/code/projects/backupninja) - Lightweight, extensible meta-backup system.
+  * [BorgBackup](https://github.com/borgbackup/borg) - A fork of [Attic](https://attic-backup.org) deduplicating backup program written in Python.
   * [Brebis](http://brebisproject.org) - A fully automated backup checker
   * [Burp](http://burp.grke.org/) - Network backup and restore program.
   * [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.


### PR DESCRIPTION
BorgBackup is a fork of Attic. Attic seams to not be actively maintained anymore. Borg added a tone of new features and many bugfixes.

> * more open, faster paced development (see [issue #1](https://github.com/borgbackup/borg/issues/1))
* lots of attic issues fixed (see [issue #5](https://github.com/borgbackup/borg/issues/5))
* less chunk management overhead (less memory and disk usage for chunks index)
* faster remote cache resync (useful when backing up multiple machines into same repo)
* compression: no, lz4, zlib or lzma compression, adjustable compression levels
* repokey replaces problematic passphrase mode (you can't change the passphrase nor the pbkdf2 iteration count in "passphrase" mode)
* simple sparse file support, great for virtual machine disk files
* can read special files (e.g. block devices) or from stdin, write to stdout
* mkdir-based locking is more compatible than attic's posix locking
* uses fadvise to not spoil / blow up the fs cache
* better error messages / exception handling
* better logging, screen output, progress indication
* tested on misc. Linux systems, 32 and 64bit, FreeBSD, OpenBSD, NetBSD, Mac OS X

https://github.com/borgbackup/borg