### PR TITLE
Added PGObserver to Metric & Metric Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ ils and flask.
   * [Diamond](https://github.com/BrightcoveOS/Diamond) - Python based statistic collection daemon.
   * [Collectd](http://collectd.org/) - System statistic collection daemon.
   * [Collectl](http://collectl.sourceforge.net/) - High precision system performance metrics collecting tool.
+  * [PGObserver](https://github.com/zalando/PGObserver) - Monitoring solution for PostgreSQL databases that also works with AWS RDS.
   * [Statsd](https://github.com/etsy/statsd/) - Application statistic listener.
   * [tcollector](http://opentsdb.net/docs/build/html/user_guide/utilities/tcollector.html) - System statistic collection daemon written in Python for OpenTSDB
 


### PR DESCRIPTION
PGObserver (https://github.com/zalando/PGObserver) is an open-source monitoring solution for PostgreSQL databases. It covers almost all the metrics provided by the database engine's internal statistics collector, and works out of the box with all PostgreSQL versions (beginning with 9.0) as well as AWS RDS. 

Let me know if you have any questions. :)