### PR TITLE
Add Algernon

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 ## Web
 *Web servers.*
 
+  * [Algernon](http://algernon.roboticoverlords.org/) - Web/application server that supports Lua, live-reload, templates, Sass and HTTP/2.
   * [Apache](http://httpd.apache.org/) - Most popular web server.
   * [Caddy](https://caddyserver.com/) - Lightweight, general-purpose web server supporting HTTP/2, automatic TLS and easy configuration. Written in Go.
   * [Cherokee](http://cherokee-project.com/) - Lightweight, high-performance web server/reverse proxy.


### PR DESCRIPTION
Algernon is a web/application server written in Go with built-in support for:

* HTTP/2
* Lua
* Markdown
* Pongo2 and Amber templates
* Sass or GCSS for styling
* JSX
* BoltDB
* Redis
* PostgreSQL
* MariaDB/MySQL
* rate limiting
* graceful shutdown
* plugins
* users and permissions

http://algernon.roboticoverlords.org/

The only external dependency is `ibreadline`. This makes it easy to drop the executable on a server for quickly sharing some files or setting up a documentation server that uses Markdown backed by git.

Disclaimer: Written by me, but it has 260 stars on GitHub, has an official Homebrew package and I think it works nicely for its use. I use it every day.