### PR TITLE
Add micro in editor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@
   * [KDevelop](https://www.kdevelop.org/) - IDE by the people behind KDE.
   * [Light Table](http://lighttable.com/) - The next generation code editor.
   * [Lime](http://limetext.org/) - Aims to provide an open source solution to Sublime Text
+  * [micro](https://github.com/zyedidia/micro) - A modern and intuitive terminal-based text editor 
   * [TextMate](https://github.com/textmate/textmate/) - A graphical text editor for OS X.
   * [Vim](http://www.vim.org) - A highly configurable text editor built to enable efficient editing.
   * [Visual Studio Code](https://code.visualstudio.com/) - An open source cross-platform extensible code editor from Microsoft


### PR DESCRIPTION
Micro is a terminal-based text editor that aims to be easy to use and intuitive, while also taking advantage of the full capabilities of modern terminals. It comes as one single, batteries-included, static binary with no dependencies, and you can download and use it right now.

As the name indicates, micro aims to be somewhat of a successor to the nano editor by being easy to install and use in a pinch, but micro also aims to be enjoyable to use full time, whether you work in the terminal because you prefer it (like me), or because you need to (over ssh).

It's awesome, due:

- Free,
- Open Source
- Powerful (mouse support, tabs, syntax highlighting etc.)
- drop-in replacement to nano.