### PR TITLE
add Datadog monitoring guides to the websites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Various resources, such as books, websites and articles, for improving your skil
 
   * [Ops School](http://www.opsschool.org) - Comprehensive program that will help you learn to be an operations engineer.
   * [Digital Ocean Tutorials](https://www.digitalocean.com/community/tutorials) - A surprisingly vast resource for getting the basics of certain applications, tools, or even systems administration topics.
-  * [Datadog Monitoring Guides](https://datadoghq.com/blog?ref=awesome) - Broad collection of monitoring guides for a variety of system administration tools.
+  * [Datadog Monitoring Guides](https://www.datadoghq.com/blog?ref=awesome) - Broad collection of monitoring guides for a variety of system administration tools.
 
 
 ## Wikis

--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ Various resources, such as books, websites and articles, for improving your skil
 
   * [Ops School](http://www.opsschool.org) - Comprehensive program that will help you learn to be an operations engineer.
   * [Digital Ocean Tutorials](https://www.digitalocean.com/community/tutorials) - A surprisingly vast resource for getting the basics of certain applications, tools, or even systems administration topics.
+  * [Datadog Monitoring Guides](https://datadoghq.com/blog?ref=awesome) - Broad collection of monitoring guides for a variety of system administration tools.
 
 
 ## Wikis


### PR DESCRIPTION
[Datadog](https://github.com/DataDog/dd-agent) is an open source tool for metrics collection, written in Python. 

The [Datadog blog](https://datadoghq.com/blog) is a compendium of well-researched, peer-reviewed monitoring guides. The monitoring guides are vendor-neutral, and detail not only the most important metrics to collect for a particular technology, but also how to collect those metrics using native tools, or third-party open source tools.

Please let me know if a direct link to the blog is innapropriate; the research team at Datadog also maintains a [repository](https://github.com/DataDog/the-monitor) for all of the longform monitoring guides which may be more appropriate for inclusion in this list.