### PR TITLE
Add munki to Deployment Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@
   * [Mina](http://nadarei.co/mina/) - Really fast deployer and server automation tool (rake based).
   * [Rocketeer](http://rocketeer.autopergamene.eu/) - PHP task runner and deployment tool.
   * [Vlad the Deployer](https://github.com/seattlerb/vlad) - Deployment automation (rake based).
+  * [munki](https://www.munki.org/munki/) - Webserver-based repository of packages and package metadata, that allows macOS administrators to manage software installs. 
 
 
 ## Distributed Filesystems


### PR DESCRIPTION
munki should be added, since it's a standard in many macOS environments today.