### PR TITLE
Add pihole project as a dns service

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@
   * [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) - A lightweight service providing DNS, DHCP and TFTP services to small-scale networks.
   * [Knot](https://www.knot-dns.cz/) - High performance authoritative-only DNS server.
   * [NSD](http://www.nlnetlabs.nl/projects/nsd/) - Authoritative only, high performance, simple name server.
+  * [Pi-hole](https://pi-hole.net/) - Network wide hardware adblocking (using a DNS server on a Raspberry Pi)
   * [PowerDNS](https://www.powerdns.com/) - DNS server with a variety of data storage back-ends and load balancing features.
   * [Unbound](http://unbound.net/) - Validating, recursive, and caching DNS resolver.
   * [Yadifa](http://www.yadifa.eu/) - Lightweight authoritative Name Server with DNSSEC capabilities powering the .eu top-level domain.


### PR DESCRIPTION
Add Pi-hole an network wide ad blocking dns service. It is awesome since it blocks all ads on your network, including ads on your phone and other devices not usually easy to block ads on.