### PR TITLE
Add eZ Server Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@
   * [cadvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers ([Source Code](https://github.com/google/cadvisor)) `Apache` `Go`
   * [check_mk](http://mathias-kettner.com/check_mk.html) - Collection of extensions for Nagios.
   * [Dash](https://github.com/afaqurk/linux-dash) - A low-overhead monitoring web dashboard for a GNU/Linux machine.
+  * [eZ Server Monitor](http://www.ezservermonitor.com) - A lightweight and simple dashboard monitor for Linux, available in Web and Bash application.
   * [Flapjack](http://flapjack.io/) - Monitoring notification routing & event processing system.
   * [Healthchecks](https://healthchecks.io/) - Monitoring for cron jobs, background services and scheduled tasks.
   * [Icinga](https://www.icinga.org/) - Nagios fork that has since lapped nagios several times. Comes with the possibility of clustered monitoring - ([Source Code](https://github.com/Icinga)) - `GPLv2`


### PR DESCRIPTION
**eZ Server Monitor** is a lightweight and simple dashboard monitor for Linux available in Web and Bash application.

In its Web version, eZ Server Monitor is a PHP script which provides a web page containing information such as the operating system, the number of users connected to the server, the system load, CPU, memory RAM, available disk space, bandwidth usage, and especially the port monitoring services such as FTP, SMTP, Web, etc ...

eZ Server Monitor`sh is a Bash script displays on your console information such as the operating system, system load, CPU, RAM, disk space available, network information, temperatures, etc ...

- Official Website : http://www.ezservermonitor.com
- GitHub for eSM Web : https://github.com/shevabam/ezservermonitor-web
- GitHub for eSM sh : https://github.com/shevabam/ezservermonitor-sh

Under _Monitoring_ category.