### PR TITLE
Remove Obnam

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@
   * [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
   * [Elkarbackup](https://github.com/elkarbackup/elkarbackup) - Backup solution based on RSnapshot with a simple web interface
   * [Lsyncd](https://github.com/axkibe/lsyncd) - File Monitor which spawns a process to synchronize the changes (rsync by default).
-  * [Obnam](http://obnam.org/) - An easy, secure, snapshots-based backup program with data de-duplication.
   * [Rdiff-backup](http://www.nongnu.org/rdiff-backup/) - An easy A remote incremental backup of all your files.
   * [Rsnapshot](http://rsnapshot.org/) - Filesystem Snapshotting Utility.
   * [Shield](https://github.com/starkandwayne/shield) - A pluggable architecture for backup and restore of database systems.


### PR DESCRIPTION
Project is retired and shouldn't be used, per their website:

NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE!

The Obnam project is retired. See https://blog.liw.fi/posts/2017/08/13/retiring_obnam/ for more information. Please use another backup solution instead.

NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE! NOTE!