### PR TITLE
Add MTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
   + [grml](https://grml.org) – bootable Debian Live CD with powerful CLI tools.
   * [mitmproxy](http://mitmproxy.org/) - A Python tool used for intercepting, viewing and modifying network traffic. Invaluable in troubleshooting certain problems.
+  * [mtr](https://www.bitwizard.nl/mtr/) - Network utility that combines traceroute and ping.
   * [perf-tools](https://github.com/brendangregg/perf-tools) - Performance analysis tools based on Linux perf_events (aka perf) and ftrace.
   * [Sysdig](http://www.sysdig.org/) - Capture system state and activity from a running Linux instance, then save, filter and analyze.
   * [Dripcap](https://github.com/dripcap/dripcap) - Caffeinated Packet Analyzer.


### PR DESCRIPTION
MTR is basically a combination of traceroute and ping - I've used it
frequently to diagnose routing issues between hosts, and it's come in
handy multiple times.