### PR TITLE
Add Wireguard to the VPN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
   * [sshuttle](https://github.com/apenwarr/sshuttle) - Poor man's VPN.
   * [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux.
   * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
+  * [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto. Linux only (2017); other clients in development.
 
 
 ## Web


### PR DESCRIPTION
### Application name / category
[WireGuard](https://www.wireguard.com/) / VPN

### Source URL
https://git.zx2c4.com/WireGuard/

### why it is awesome
Wireguard is a new VPN based on elliptic curve crypto (Curve25519, ChaCha20, Poly1305) and public key cryptography. It has a very small attack surface and is extremely fast. It's currently used in production by Mullvad VPN and AzireVPN.
