### PR TITLE
Add iptraf - console-based network statistics utility for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 
 *Troubleshooting Tools.*
 
+* [iptraf](http://iptraf.seul.org/) - IPTraf is a console-based network statistics utility for Linux.
 * [grml](https://grml.org) – bootable Debian Live CD with powerful CLI tools.
 * [mitmproxy](http://mitmproxy.org/) - A Python tool used for intercepting, viewing and modifying network traffic. Invaluable in troubleshooting certain problems.
 * [mtr](https://www.bitwizard.nl/mtr/) - Network utility that combines traceroute and ping.


### PR DESCRIPTION
### Application name / category
* iptraf / Troubleshooting

### Source URL
http://iptraf.seul.org/

### why it is awesome
It is awesome because it helps to analyze network traffic on remote servers using ng-like interface.
