### PR TITLE
Add xiringuito - SSH-based "VPN for poors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [sshuttle](https://github.com/apenwarr/sshuttle) - Poor man's VPN.
 * [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux.
 * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
+* [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN for poors.
 
 ## Web
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [sshuttle](https://github.com/apenwarr/sshuttle) - Poor man's VPN.
 * [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux.
 * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
-* [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based VPN for poors.
+* [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based "VPN for poors".
 
 ## Web
 


### PR DESCRIPTION
### Application name / category
xiringuito / VPN

### Source URL
https://github.com/ivanilves/xiringuito

### why it is awesome
`xiringuito` is awesome, because:
* easy to install (no dependencies, no configurations)
* allows you to manage one, few or many connections easily (and connect em simultaneously if you want)
* it has `xaval` connection manager - a tool that may record and later re-use your connection profiles
* though you are free to use or not to use `xaval` connection manager - people also use `xiringuito` for ad-hoc onetime connections
* Just look at this GIF :wink: 
![](https://github.com/ivanilves/xiringuito/raw/master/images/install.gif)