### PR TITLE
Add SSL-CP

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@
 * [OSIAM](http://osiam.github.io/) - Secure identity management solution providing REST based services for authentication and authorization.
 * [Samba](https://www.samba.org/) – Active Directory and CIFS protocol implementation.
 * [BounCA](https://bounca.org/) - A personal SSL Key / Certificate Authority web-based tool for creating self-signed certificates.
+* [SSL-CP](https://github.com/reddec/ssl-cp) - SSL Key / multi Certificate Authority web-based tool for creating self-signed certificates with different exports options (PEM, PFX) and cookbooks (generates config for Stunnel, Nginx and etc.)
 
 ## IT Asset Management
 


### PR DESCRIPTION
Another SSL/CA management tool

### Application name / category
[ssl-cp](https://github.com/reddec/ssl-cp) / Tools and web interfaces

### Source URL
https://github.com/reddec/ssl-cp

### why it is awesome

Web-based tool for creating self-signed certificates with some key features:

* multi-project (multiple CA)
* generate or upload CA key
* exports all-in-one (PFX, PEM) or separately certificates and/or keys
* automation oriented: all API designed keeping in mind future automation (clean url, curl'able links and else)
* cookbooks: generates config for Stunnel, Nginx (optionally with client authorization) and will be more in the future
* docker and cloud deployment oriented
