### PR TITLE
add edmon simple cli monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@
 * [cadvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers ([Source Code](https://github.com/google/cadvisor)) `Apache` `Go`
 * [check_mk](http://mathias-kettner.com/check_mk.html) - Collection of extensions for Nagios.
 * [Dash](https://github.com/afaqurk/linux-dash) - A low-overhead monitoring web dashboard for a GNU/Linux machine.
+* [EdMon](https://gituh.com/Edraens/EdMon) - A command-line monitoring application helping you to check that your hosts and services are available, with notifications support. `MIT` `Java`
 * [ElastiFlow](https://github.com/robcowart/elastiflow) - Network flow Monitoring (Netflow, sFlow and IPFIX) with the Elastic Stack.
 * [eZ Server Monitor](http://www.ezservermonitor.com) - A lightweight and simple dashboard monitor for Linux, available in Web and Bash application.
 * [Flapjack](http://flapjack.io/) - Monitoring notification routing & event processing system.


### PR DESCRIPTION
### Application name / category
[EdMon](https://github.com/Edraens/EdMon) / Monitoring

### Source URL
https://github.com/Edraens/EdMon

### why it is awesome
A command-line monitoring application helping you to check that your hosts and services are available, with notifications support.
