### PR TITLE
Adding GLAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,13 +332,14 @@
 
 ## Identity Management
 
-*LDAP servers and other tools to manage accounts and identities.*
+*servers and other tools to manage accounts and identities.*
 
 ### LDAP
 
 * [389 Directory Server](http://www.port389.org/) - Developed by Red Hat.
 * [Apache Directory Server](http://directory.apache.org/) - Apache Software Foundation project written in Java.
 * [FreeRADIUS](http://freeradius.org/) - High performance and highly configurable multi-protocol policy/authentication server, supporting RADIUS, DHCPv4 and VMPS.
+* [GLAuth](https://github.com/glauth/glauth) - Simple and lightweight LDAP server in Golang.
 * [OpenDJ](http://opendj.forgerock.org/) - Fork of OpenDS.
 * [OpenDS](https://opends.java.net/) - Another directory server written in Java.
 * [OpenLDAP](http://www.OpenLDAP.org/) - Developed by the OpenLDAP Project.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@
 
 ## Identity Management
 
-*servers and other tools to manage accounts and identities.*
+*LDAP servers and other tools to manage accounts and identities.*
 
 ### LDAP
 


### PR DESCRIPTION
### Application name / category
[GLAuth](https://github.com/glauth/glauth) / LDAP server

### Source URL
https://github.com/glauth/glauth

### why it is awesome
This tool is a great, lightweight LDAP server, especially suitable for homelabs or simpler situations. While it doesn't pretend to be as full featured as other LDAP servers, that is by design - setting many of the LDAP servers out there is often a complicated process - with GLAuth, it's a single statically linked binary, which can be run in either a docker container or on metal, with only a single configuration file.

Finally, docker is a first-class release method, allowing users to mount a single config file, and run the latest version in their existing docker infrastructure, with no additional hassle. 

Thanks for considering it.

_Disclaimer: I am the maintainer._

Note: I'll add another PR redirecting to the github pages site when it's complete. In the meantime, the repo is the best source for public interest.