### PR TITLE
add PiVPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [ocserv](http://www.infradead.org/ocserv/) - Cisco AnyConnect-compatible VPN server
 * [OpenVPN](https://community.openvpn.net) - Uses a custom security protocol that utilizes SSL/TLS for key exchange.
 * [Pritunl](http://pritunl.com/) - OpenVPN based solution. Easy to set up.
+* [PiVPN](http://www.pivpn.io/) - Simple OpenVPN based setup designed for Raspberry Pi (runs on any Debian-based distro).
 * [SoftEther](https://www.softether.org/) - Multi-protocol software VPN with advanced features
 * [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN.
 * [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux.


### PR DESCRIPTION

### Application name / category
[PiVPN](http://www.pivpn.io/) / VPN

### Source URL
https://github.com/pivpn/pivpn

### why it is awesome
PiVPN is a dead-simple OpenVPN implementation. While it was designed for the Raspberry Pi, it runs on any Debian-based Linux distribution.

