### PR TITLE
Add deb.sury.org as source for the LAMP Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ Various resources, such as books, websites and articles, for improving your skil
 
 ### Debian-based distributions
 
-* [Dotdeb](https://www.dotdeb.org/) - Repository with LAMP updated packages for Debian.
+* [deb.sury.org](https://deb.sury.org/) - Repository with LAMP updated packages for Debian and Ubuntu.
 
 ### RPM-based distributions
 


### PR DESCRIPTION
This PR adds the deb.sury.org as new source for an up-to-date LAMP Stack as dotdeb is discontinued for newer PHP Versions: https://www.dotdeb.org/2017/01/27/php-7-1-dotdeb/ behind the deb.sury.org project you can find the author of the official packages more details can be found here: https://deb.sury.org/

For the reason above I have marked the dotdeb site as discontinued or should it be removed from this list?