### PR TITLE
Rclone is not really a backup solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@
 * [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
 * [Elkarbackup](https://github.com/elkarbackup/elkarbackup) - Backup solution based on RSnapshot with a simple web interface
 * [Lsyncd](https://github.com/axkibe/lsyncd) - File Monitor which spawns a process to synchronize the changes (rsync by default).
-* [rclone](https://rclone.org/) - a command line program to sync files and directories to and from several cloud storage systems/providers.
 * [Rdiff-backup](http://www.nongnu.org/rdiff-backup/) - An easy A remote incremental backup of all your files.
 * [Restic](https://restic.net/) - Secure, remote backup tool. Designed to be easy, fast, verifiable and efficient.
 * [Rsnapshot](http://rsnapshot.org/) - Filesystem Snapshotting Utility.


### PR DESCRIPTION
* [rclone](https://rclone.org/) - a command line program to sync files and directories to and from several cloud storage systems/providers.
is listed under backups. I think it should be categorized elsewhere, but I can't think of a place.
Rclone is mainly used for cloud to local/local to cloud/cloud to cloud one-time transfers, it can be used as a one-way synchronization (not backup, though there is --backup-dir, what moves the file to a 'trash bin').