### PR TITLE
Add entry for spack package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 * [EasyBuild](https://easybuild.readthedocs.org/en/latest/) - EasyBuild builds software and modulefiles for High Performance Computing (HPC) systems in an efficient way.
 * [environment-modules Lmod](https://www.tacc.utexas.edu/research-development/tacc-projects/lmod) - Lmod is a Lua based module system that easily handles the MODULEPATH Hierarchical problem.
 * [HPCBIOS](http://hpcbios.readthedocs.org/en/latest/) - HPCBIOS is an effort to setup a common, well-documented and reproducible, environment spanning across multiple HPC systems & sites, *inclusive* of documentation.
+* [Spack](https://spack.io/) - A flexible package manager that supports multiple versions, configurations, platforms, and compilers.
 
 ## ChatOps
 


### PR DESCRIPTION
### Application name / category
[Spack](https://spack.io/) / Build and software organization tools

### Source URL
https://github.com/spack/spack

### why it is awesome
This tool is awesome because it allows for the installation of multiple versions of the same software to coexist on a system and makes managing software for an HPC environment simple and reproducible.