### PR TITLE
Add category Diagramming, with tools Mermaid, DrawTheNet, and Diagrams.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   * [Continuous Integration & Continuous Deployment](#continuous-integration--continuous-deployment)
   * [Control Panels](#control-panels)
   * [Deployment Automation](#deployment-automation)
+  * [Diagramming](#diagramming)
   * [Distributed Filesystems](#distributed-filesystems)
   * [DNS](#dns)
   * [Domains](#domains)
@@ -265,6 +266,13 @@
 * [Rocketeer](http://rocketeer.autopergamene.eu/) - PHP task runner and deployment tool.
 * [sup](https://github.com/pressly/sup/) - Super simple deployment tool - just Unix - think of it like 'make' for a network of servers.
 * [Vlad the Deployer](https://github.com/seattlerb/vlad) - Deployment automation (rake based).
+
+## Diagramming
+
+*Tools used to create diagrams of networks, flows, etc.*
+
+* [DrawThe.Net](http://go.drawthe.net/) - Javascript tool that uses a YAML-formatted input to programmatically create large, complex, and visually solid diagrams.
+* [Mermaid](https://mermaid-js.github.io/mermaid-live-editor/) - Javascript module with a unique, easy, shorthand syntax. Integrates into several other tools like Grafana.
 
 ## Distributed Filesystems
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@
 
 * [DrawThe.Net](http://go.drawthe.net/) - Javascript tool that uses a YAML-formatted input to programmatically create large, complex, and visually solid diagrams.
 * [Mermaid](https://mermaid-js.github.io/mermaid-live-editor/) - Javascript module with a unique, easy, shorthand syntax. Integrates into several other tools like Grafana.
+* [Diagrams.net](https://app.diagrams.net/) - A.K.A. [Draw.io](https://app.diagrams.net/). Easy to use Diagram UI with a plethora of templates.
 
 ## Distributed Filesystems
 


### PR DESCRIPTION
### Application name / category

[Mermaid](https://mermaid-js.github.io/mermaid-live-editor/) / Diagramming  
[DrawThe.Net](http://go.drawthe.net/) / Diagramming

### Source URL

MermaidJS: https://github.com/mermaid-js/mermaid-live-editor  
DrawTheNet: https://github.com/cidrblock/drawthe.net

### why it is awesome

#### MermaidJS

Mermaid has a very easy and quick syntax, making it incredibly useful for throwing together quick diagrams on-the-fly. It also has a decent amount of diagram types, making it pretty versatile. It has a CLI interface you can use locally to generate the diagrams yourself. It integrates with [Grafana](https://grafana.com/) via a plugin.

#### DrawTheNet

> **Note**: This is on the [master repo](https://github.com/kahun/awesome-sysadmin#diagramming) that this was forked from, which makes me believe it was on here at one point, but I cannot find neither a commit nor a PR noting its removal. It is _not_ actively updated, but still functional and very useful as-is.

DrawTheNet is like Mermaid on steroids. It has a _lot_ more it can do, and is a lot more expansive and versatile. The downside here is that the syntax has to be a bit more complicated to be able to do this.

DrawTheNet uses YAML syntax.