### PR TITLE
Add slackhq/Nebula VPN to list of VPN software

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux.
 * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
 * [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto.
+* [Nebula](https://github.com/slackhq/nebula) - A scalable p2p VPN with a focus on performance, simplicity and security.
 
 ## Web
 


### PR DESCRIPTION
### Application name / category
[Nebula](https://github.com/slackhq/nebula) / VPN

### Source URL
https://github.com/slackhq/nebula

### why it is awesome
Nebula is simple and secure VPN for p2p communication. It uses the Noise encryption protocol for encrypting traffic and runs on all major platforms (iOS, Android, Linux, Mac, Windows)
