### PR TITLE
Add AdGuard Home to DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@
   * [nsedit](https://github.com/tuxis-ie/nsedit) - nsedit is a DNS editor for PowerDNS, working with PowerDNS's new API.
   * [PDNS Gui](https://github.com/odoucet/pdns-gui) - WebGUI which aids in administering domains and records for PowerDNS with MySQL.
   * [Pi-hole](https://pi-hole.net/) - A blackhole for Internet Advertisements with a gui for managing and monitoring
+  * [AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) - A network-wide ads & trackers blocking DNS server
   * [Poweradmin](http://www.poweradmin.org/) - Friendly web-based DNS administration tool for PowerDNS server.
 * Revision Control: see [awesome-selfhosted#project-management](https://github.com/Kickball/awesome-selfhosted#project-management)
 * Virtualization


### PR DESCRIPTION
Add AdGuard Home to DNS section

### Application name / category
[AdGuard Home](https://adguard.com/en/adguard-home/overview.html) / DNS

### Source URL
https://github.com/AdguardTeam/AdGuardHome

### why it is awesome
A network-wide software for blocking ads & tracking, similar to Pi-Hole.
