### PR TITLE
Adding CDS to CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@
 
 - [Buildbot](http://buildbot.net/) - Python-based toolkit for continuous integration. ([Source Code](https://github.com/buildbot/buildbot)) `GPL-2.0` `Python`
 - [CapsuleCD](https://analogj.github.io/capsulecd-slides/) - CD script for automating package/library releases (npm, cookbooks, gems, pip, jars, etc). ([Source Code](https://github.com/AnalogJ/capsulecd)) `MIT` `Go`
+- [CDS](https://ovh.github.io/cds/) - Enterprise-Grade Continuous Delivery & DevOps Automation Open Source Platform  ([Source Code](https://github.com/ovh/cds)) `BSD-3-Clause` `Go`
 - [Concourse](https://concourse-ci.org/) - Concourse is a CI tool that treats pipelines as first class objects and containerizes every step along the way. ([Demo](https://ci.concourse-ci.org/), [Source Code](https://github.com/concourse/concourse)) `Apache-2.0` `Go`
 - [drone](https://drone.io/) - Drone is a Continuous Delivery platform built on Docker, written in Go. ([Source Code](https://github.com/drone/drone)) `Apache-2.0` `Go`
 - [Factor](http://www.factor.io/) - Programmatically define and run workflows to connect configuration management, source code management, build, continuous integration, continuous deployment and communication tools. ([Source Code](https://github.com/factor-io/factor)) `MIT` `Ruby`


### PR DESCRIPTION
### Application name / category
[CDS](https://ovh.github.io/cds/) / Continuous Integration & Continuous Deployment

### Source URL
https://github.com/ovh/cds

### why it is awesome

CDS, It is the end-result of 12 years' experience in the field of CI/CD. Familiar with most of the standard tools of the industry, the CDS developers found that none completely matched their expectations regarding the four key aspects they identified (Elastic, Extensible, Flexible, but easy, Self-service). That is what CDS tries to solve. 

More details on their website