### PR TITLE
Update Camlistore name to Perkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@
 
 *Network distributed filesystems.*
 
-* [Camlistore](https://camlistore.org/) - A set of open source formats, protocols, and software for modeling, storing, searching, sharing and synchronizing data.
 * [Ceph](http://ceph.com/) - Distributed object store and file system.
 * [DRBD](http://drbd.linbit.com/) - Distributed Replicated Block Device.
 * [LeoFS](http://leo-project.net) - Unstructured object/data storage and a highly available, distributed, eventually consistent storage system.
@@ -290,6 +289,7 @@
 * [MogileFS](http://mogilefs.org/) - Application level, network distributed file system.
 * [OpenAFS](http://www.openafs.org/) - Distributed network file system with read-only replicas and multi-OS support.
 * [Ori Filesystem](http://ori.scs.stanford.edu/) - A Secure Distributed File System built for offline operation.
+* [Perkeep](https://perkeep.org/) (née Camlistore) - A set of open source formats, protocols, and software for modeling, storing, searching, sharing and synchronizing data.
 * [Swift](http://docs.openstack.org/developer/swift/) - A highly available, distributed, eventually consistent object/blob store.
 * [SheepDog](https://sheepdog.github.io/sheepdog/) - A distributed Blockdevice, Rest, QEMU and distributed Filesystem storage.
 * [TahoeLAFS](https://tahoe-lafs.org/trac/tahoe-lafs) - secure, decentralized, fault-tolerant, peer-to-peer distributed data store and distributed file system.


### PR DESCRIPTION
It's been rebranded from Camlistore to Perkeep. The [old url](https://camlistore.org/) redirects, [old Github org](https://github.com/camlistore) renamed, [Wikipedia page](https://en.wikipedia.org/wiki/Perkeep) updated. It's effectively been renamed.

### Application name / category
[perkeep](https://perkeep.org/) / Network distributed filesystems

### Source URL
https://github.com/perkeep/perkeep

### why it is awesome
self-hostable storage, sync, share, search solution