### PR TITLE
Change Diamond repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@
 *Metric gathering and display software.*
 
 * Collectors only
-  * [Diamond](https://github.com/BrightcoveOS/Diamond) - Python based statistic collection daemon.
+  * [Diamond](https://github.com/python-diamond/Diamond) - Python based statistic collection daemon.
   * [Collectd](http://collectd.org/) - System statistic collection daemon.
   * [Collectl](http://collectl.sourceforge.net/) - High precision system performance metrics collecting tool.
   * [PGObserver](https://github.com/zalando/PGObserver) - Monitoring solution for PostgreSQL databases that also works with AWS RDS.


### PR DESCRIPTION
Diamond has changed repositories so I have updated it.

### Application name / category
[Diamond](https://github.com/python-diamond/Diamond) / Metric gathering and display software

### Source URL
https://github.com/python-diamond/Diamond

### why it is awesome
This tool is so awesome because it’s already on the list and it’s even more awesome to have updated links.
