### PR TITLE
Add Shimmy - Self-hosted AI inference server

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Network configuration management tools.
 - [LocalStack](https://localstack.cloud/) - LocalStack is a fully functional local AWS cloud stack. This includes Lambda for serverless computation. ([Source Code](https://github.com/localstack/localstack)) `Apache-2.0` `Python/Docker/K8S`
 - [Nhost](https://nhost.io/) - Firebase Alternative with GraphQL. Get a database and backend configured and ready in minutes. ([Source Code](https://github.com/nhost/nhost)) `MIT` `Docker/Nodejs/Go`
 - [OpenFaaS](https://www.openfaas.com/) - Serverless Functions Made Simple for Docker & Kubernetes. ([Source Code](https://github.com/openfaas/faas)) `MIT` `Go`
+- [Shimmy](https://github.com/ptsochantaris/shimmy) - Self-hosted AI inference server providing OpenAI-compatible API for local LLM deployment. Supports multiple model formats with streaming and multimodal capabilities. ([Source Code](https://github.com/ptsochantaris/shimmy)) `MIT` `Rust`
 - [Tau](https://taubyte.com) - Easily build Cloud Computing Platforms with features like Serverless WebAssembly Functions, Frontend Hosting, CI/CD, Object Storage, K/V Database, and Pub-Sub Messaging. ([Source Code](https://github.com/taubyte/tau)) `BSD-3-Clause` `Go/Rust/Docker`
 - [Trusted-CGI](https://github.com/reddec/trusted-cgi) - Lightweight self-hosted lambda/applications/cgi/serverless-functions platform. `MIT` `Go/deb/Docker`
 


### PR DESCRIPTION
## Summary
- Add Shimmy to the PaaS (Platform-as-a-Service) section
- Shimmy provides a self-hosted AI inference server with OpenAI-compatible API
- Perfect fit for sysadmins looking to deploy local AI infrastructure

## Project Details
- **Repository**: https://github.com/ptsochantaris/shimmy
- **Category**: PaaS (placed alphabetically between OpenFaaS and Tau)
- **License**: MIT
- **Language**: Rust
- **Description**: Self-hosted AI inference server providing OpenAI-compatible API for local LLM deployment

## Why This Fits Awesome Sysadmin
- **Infrastructure Focus**: Sysadmins need to deploy and manage AI inference services
- **Self-hosted Solution**: Perfect for organizations wanting to keep AI workloads on-premises
- **API Service**: Provides platform-as-a-service functionality for AI inference
- **Production Ready**: Designed for enterprise deployment with Docker support
- **Resource Management**: Allows sysadmins to control AI compute resources locally

## Technical Benefits for Sysadmins
- OpenAI-compatible API (familiar interface)
- Multiple model format support (flexibility)
- Streaming capabilities (performance)
- Container deployment (easy operations)
- Multimodal support (comprehensive AI platform)

## Test plan
- [x] Verified project is appropriate for sysadmin infrastructure management
- [x] Placed in correct alphabetical order in PaaS section
- [x] Followed formatting conventions (description, source code link, license, language)
- [x] Confirmed project is actively maintained and production-ready

🤖 Generated with [Claude Code](https://claude.ai/code)