### PR TITLE
Add Tokyo VPN Speed Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ VPN software.
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN. `LGPL-2.1` `Python`
 - [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux. ([Source Code](https://github.com/strongswan/strongswan)) `GPL-2.0` `C`
 - [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto. ([Source Code](https://www.wireguard.com/repositories/)) `GPL-2.0` `C`
+- [Tokyo VPN Monitor](https://www.blstweb.jp/network/vpn/) - Automated VPN performance testing from Tokyo. 1245+ measurements, 99.8% uptime, $0/month operating cost. Open source (MIT).
 
 
 ### Web

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ VPN software.
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN. `LGPL-2.1` `Python`
 - [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux. ([Source Code](https://github.com/strongswan/strongswan)) `GPL-2.0` `C`
 - [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto. ([Source Code](https://www.wireguard.com/repositories/)) `GPL-2.0` `C`
-- [Tokyo VPN Monitor](https://www.blstweb.jp/network/vpn/) - Automated VPN performance testing from Tokyo. 1245+ measurements, 99.8% uptime, $0/month operating cost. Open source (MIT).
+- [Tokyo VPN Monitor](https://www.blstweb.jp/network/vpn/) - Automated VPN performance testing from Tokyo. 1245+ measurements, 99.8% uptime, $0/month operating cost. Open source (MIT).([Source Code](https://github.com/hmy0210/vpn-stability-ranking)) 
 
 
 ### Web

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ VPN software.
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN. `LGPL-2.1` `Python`
 - [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux. ([Source Code](https://github.com/strongswan/strongswan)) `GPL-2.0` `C`
 - [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto. ([Source Code](https://www.wireguard.com/repositories/)) `GPL-2.0` `C`
-- [Tokyo VPN Monitor](https://www.blstweb.jp/network/vpn/) - Automated VPN performance testing from Tokyo. 1245+ measurements, 99.8% uptime, $0/month operating cost. Open source (MIT).([Source Code](https://github.com/hmy0210/vpn-stability-ranking)) 
+- [Tokyo VPN Monitor](https://www.blstweb.jp/network/vpn/tokyo-vpn-speed-monitor/) - Automated VPN performance testing from Tokyo. 1245+ measurements, 99.8% uptime, $0/month operating cost. Open source (MIT).([Source Code](https://github.com/hmy0210/vpn-stability-ranking)) 
 
 
 ### Web


### PR DESCRIPTION
## Description
   
   Adding Tokyo VPN Speed Monitor to the list.
   
   ## Project Details
   
   - **Name:** Tokyo VPN Speed Monitor
   - **URL:** [https://www.blstweb.jp/network/vpn/](https://www.blstweb.jp/network/vpn/)
   - **GitHub:** [https://github.com/hmy0210/vpn-stability-ranking](https://github.com/hmy0210/vpn-stability-ranking)
   - **License:** MIT
   
   ## Why this project belongs here
   
   - Automated VPN performance testing (1245+ measurements)
   - Open source and transparent (zero revenue model)
   - Public REST API for data access
   - 99.8% uptime on $0/month infrastructure
   - Useful for network security research and VPN evaluation
   
   ## Features
   
   - 15 VPN providers tested every 6 hours
   - Statistical analysis (Coefficient of Variation)
   - Anomaly detection
   - Free VPN leak detection tool
   - All code and data public