### PR TITLE
Add What Broke Today to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface. ([Source Code](https://github.com/opinkerfi/adagios)) `AGPL-3.0` `Docker/Python`
 - [Alerta](https://alerta.io/) - Distributed, scalable and flexible monitoring system. ([Source Code](https://github.com/alerta/alerta)) `Apache-2.0` `Python`
 - [Beszel](https://beszel.dev/) - Lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions. ([Source Code](https://github.com/henrygd/beszel)) `MIT` `Go`
+- [What Broke Today](https://whatbroke.today/) - AI-powered outage aggregator tracking 100+ cloud services with real-time Telegram alerts. ([Source Code](https://github.com/reshadat/whatbroketoday)) `MIT` `Python`
 - [Cacti](https://www.cacti.net) - Web-based network monitoring and graphing tool. ([Source Code](https://github.com/Cacti/cacti)) `GPL-2.0` `PHP`
 - [cadvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers. `Apache-2.0` `Go`
 - [checkmk](https://checkmk.com/) - Comprehensive solution for monitoring of applications, servers, and networks. ([Source Code](https://github.com/Checkmk/checkmk)) `GPL-2.0` `Python/PHP`


### PR DESCRIPTION
## Summary

Adding [What Broke Today](https://whatbroke.today/) to the Monitoring section.

**What Broke Today** is an AI-powered outage aggregator that:
- Monitors 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare, etc.)
- Uses AI to filter and summarize service outages
- Provides real-time Telegram alerts
- Offers RSS feed and JSON API

**Website**: https://whatbroke.today
**Source Code**: https://github.com/reshadat/whatbroketoday
**License**: MIT
**Tech Stack**: Python