### PR TITLE
Add n01d-forge and n01d-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Software that does not fit in another section.
 - [Clonezilla](https://clonezilla.org/) - Partition and disk imaging/cloning program. ([Source Code](https://clonezilla.org/downloads/src/)) `GPL-2.0` `Perl/Shell/Other`
 - [DadaMail](https://dadamailproject.com/) - Mailing List Manager, written in Perl. ([Source Code](https://sourceforge.net/projects/dadamail/files/)) `GPL-2.0` `Perl`
 - [Fog](https://www.fogproject.org/) - Cloning/imaging solution/rescue suite. ([Source Code](https://github.com/FOGProject/fogproject)) `GPL-3.0` `PHP/Shell`
+- [n01d-forge](https://github.com/bad-antics/n01d-forge) - Native GUI image burner with LUKS/VeraCrypt encryption support for creating secure bootable drives. `MIT` `Rust`
 - [phpList](https://www.phplist.org/) - Newsletter and email marketing software. ([Source Code](https://github.com/phpList/phplist3)) `AGPL-3.0` `PHP`
 
 
@@ -688,6 +689,7 @@ Virtualization software.
 - [KVM](https://www.linux-kvm.org) - Linux kernel virtualization infrastructure. ([Source Code](https://git.kernel.org/pub/scm/virt/kvm/kvm.git/)) `GPL-2.0/LGPL-2.0` `C`
 - [OpenNebula](https://opennebula.org/) - Build and manage enterprise clouds for virtualized services, containerized applications and serverless computing. ([Source Code](https://github.com/OpenNebula/one)) `Apache-2.0` `C++`
 - [oVirt](https://www.ovirt.org/) - Manages virtual machines, storage and virtual networks. ([Source Code](https://github.com/oVirt)) `Apache-2.0` `Java`
+- [n01d-machine](https://github.com/bad-antics/n01d-machine) - Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization. `MIT` `Rust`
 - [Packer](https://www.packer.io/) - A tool for creating identical machine images for multiple platforms from a single source configuration. ([Source Code](https://github.com/hashicorp/packer)) `MPL-2.0` `Go`
 - [Proxmox VE](https://www.proxmox.com/proxmox-ve) - Virtualization management solution. ([Source Code](https://git.proxmox.com/)) `GPL-2.0` `Perl/Shell`
 - [QEMU](https://www.qemu.org/) - QEMU is a generic machine emulator and virtualizer. ([Source Code](https://gitlab.com/qemu-project/qemu)) `LGPL-2.1` `C`


### PR DESCRIPTION
## Description
Adds two Rust-based sysadmin tools to appropriate sections.

## Additions

### n01d-forge (Miscellaneous section)
- **Description**: Native GUI image burner with LUKS/VeraCrypt encryption support for creating secure bootable drives
- **License**: MIT
- **Language**: Rust
- **GitHub**: https://github.com/bad-antics/n01d-forge
- Complements existing disk imaging tools like Clonezilla and Fog

### n01d-machine (Virtualization section)
- **Description**: Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization
- **License**: MIT
- **Language**: Rust
- **GitHub**: https://github.com/bad-antics/n01d-machine
- Provides security-focused VM management

Both tools are open source and built with egui for cross-platform native GUI support.