### PR TITLE
Add n01d-sysmon - Cyberpunk system monitoring toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [Linux Dash](https://github.com/afaqurk/linux-dash) - A low-overhead monitoring web dashboard for a GNU/Linux machine. `MIT` `Nodejs/Go/Python/PHP`
 - [Monit](https://mmonit.com/monit/#home) - Small utility for managing and monitoring Unix systems. ([Source Code](https://bitbucket.org/tildeslash/monit/src/master/)) `AGPL-3.0` `C`
 - [Munin](https://munin-monitoring.org/) - Networked resource monitoring tool. ([Source Code](https://github.com/munin-monitoring/munin)) `GPL-2.0` `Perl/Shell`
+- [n01d-sysmon](https://github.com/bad-antics/n01d-sysmon) - Cyberpunk-themed system monitoring toolkit with ASCII dashboards, real-time metrics, and alerting. Combines htop-style interface with hacker aesthetics. ([Source Code](https://github.com/bad-antics/n01d-sysmon)) `MIT` `Python`
 - [Naemon](https://www.naemon.org/) - Network monitoring tool based on the Nagios 4 core with performance enhancements and new features. ([Source Code](https://github.com/naemon/naemon-core)) `GPL-2.0` `C`
 - [Nagios](https://www.nagios.org/) - Computer system, network and infrastructure monitoring software application. ([Source Code](https://github.com/NagiosEnterprises/nagioscore)) `GPL-2.0` `C`
 - [Netdata](https://www.netdata.cloud/) - Distributed, real-time, performance and health monitoring for systems and applications. Runs on Linux, FreeBSD, and MacOS. ([Source Code](https://github.com/netdata/netdata)) `GPL-3.0` `C`


### PR DESCRIPTION
## Adding n01d-sysmon

**Repository:** https://github.com/bad-antics/n01d-sysmon

### Description
n01d-sysmon is a cyberpunk-themed system monitoring toolkit featuring:
- **ASCII Dashboards** - Terminal-based visualization with hacker aesthetics
- **Real-Time Metrics** - CPU, memory, disk, and network monitoring
- **Alert System** - Configurable thresholds and notifications
- **htop-Inspired** - Familiar interface with enhanced visual style

### Format
Follows the list format: `- [Name](url) - Description. ([Source Code](url)) \`LICENSE\` \`LANG\``

### Placement
Added to **Monitoring** section in alphabetical order between Munin and Naemon.

### Checklist
- [x] Follows contribution guidelines
- [x] Open source (MIT license)
- [x] Actively maintained
- [x] Alphabetically ordered