### PR TITLE
Add osx-proxmox to Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ Virtualization software.
 - [Ganeti](https://www.ganeti.org/) - Cluster virtual server management software tool built on top of KVM and Xen. ([Source Code](https://github.com/ganeti/ganeti)) `BSD-2-Clause` `Python/Haskell`
 - [KVM](https://www.linux-kvm.org) - Linux kernel virtualization infrastructure. ([Source Code](https://git.kernel.org/pub/scm/virt/kvm/kvm.git/)) `GPL-2.0/LGPL-2.0` `C`
 - [OpenNebula](https://opennebula.org/) - Build and manage enterprise clouds for virtualized services, containerized applications and serverless computing. ([Source Code](https://github.com/OpenNebula/one)) `Apache-2.0` `C++`
+- [osx-proxmox](https://github.com/lucid-fabrics/osx-proxmox-next) - One-command macOS VM automation for Proxmox with TUI wizard and recovery auto-download. ([Source Code](https://github.com/lucid-fabrics/osx-proxmox-next)) `Apache-2.0` `Python`
 - [oVirt](https://www.ovirt.org/) - Manages virtual machines, storage and virtual networks. ([Source Code](https://github.com/oVirt)) `Apache-2.0` `Java`
 - [Packer](https://www.packer.io/) - A tool for creating identical machine images for multiple platforms from a single source configuration. ([Source Code](https://github.com/hashicorp/packer)) `MPL-2.0` `Go`
 - [Proxmox VE](https://www.proxmox.com/proxmox-ve) - Virtualization management solution. ([Source Code](https://git.proxmox.com/)) `GPL-2.0` `Perl/Shell`


### PR DESCRIPTION
## Why is it awesome?

osx-proxmox eliminates 6+ hours of manual OpenCore configuration to run macOS VMs on Proxmox. A single command launches a TUI wizard that handles everything — OpenCore setup, recovery image download, VM creation — for Sonoma, Sequoia, and Tahoe on AMD and Intel.

## Have you used it?

Yes, actively maintained and used in my homelab for macOS development VMs on a 5-node Proxmox cluster.

## Personal or professional setup?

Personal homelab.

## Biggest pros vs. other solutions?

- vs manual OpenCore: 5 min vs 6+ hours, no error-prone config editing
- vs Packer/Vagrant: simpler, purpose-built for Proxmox macOS
- Supports AMD CPUs (many guides are Intel-only)
- Auto-downloads recovery images from Apple's servers

## Other comments

Already integrated into [community-scripts/ProxmoxVE](https://github.com/community-scripts/ProxmoxVE). Apache 2.0, Python, active development.