### PR TITLE
Add SSL Certificate Monitor - SSL expiry monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Miscellaneous utilities and web interfaces for identity management systems.
 - [Pomerium](https://www.pomerium.io/) - An identity and context aware access-proxy inspired by BeyondCorp. ([Source Code](https://github.com/pomerium/pomerium)) `Apache-2.0` `Docker/Go`
 - [Samba](https://www.samba.org/) - Active Directory and CIFS protocol implementation. ([Source Code](https://download.samba.org/pub/samba/)) `GPL-3.0` `C`
 - [Smallstep Certificates](https://smallstep.com/certificates/) - A private certificate authority (X.509 & SSH) and related tools for secure automated certificate management. ([Source Code](https://github.com/smallstep/certificates)) `Apache-2.0` `Go`
+- [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) - Free SSL certificate expiry checker and monitoring tool with RESTful API. ([Demo](https://ssl-certificate-monitor.autocompany.workers.dev)) `MIT` `Cloudflare Workers`
 - [ZITADEL](https://zitadel.com/) - Cloud-native Identity & Access Management solution providing a platform for secure authentication, authorization and identity management. ([Source Code](https://github.com/zitadel/zitadel)) `Apache-2.0` `Go/Docker/K8S`
 
 


### PR DESCRIPTION
## Summary
Add SSL Certificate Monitor - a free SSL certificate expiry checker and monitoring tool.

## Features
- Check SSL certificate expiry dates
- View certificate details (issuer, algorithm, SANs)
- RESTful API for programmatic access
- Web UI for manual checks
- No signup required

## Links
- Demo: https://ssl-certificate-monitor.autocompany.workers.dev
- GitHub: https://github.com/brancogao/ssl-certificate-monitor

## Checklist
- [x] The item is not already in the list
- [x] The item has a description
- [x] The item follows the alphabetical order
- [x] The item has demo link where applicable