### PR TITLE
Add Agent-SRE to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Monitoring software.
 _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 
 - [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface. ([Source Code](https://github.com/opinkerfi/adagios)) `AGPL-3.0` `Docker/Python`
+- [Agent-SRE](https://github.com/imran-siddique/agent-sre) - AI-native Site Reliability Engineering framework with SLI/SLO tracking, chaos testing, canary deployments, and automated incident response for AI agent systems. `MIT` `Python`
 - [Alerta](https://alerta.io/) - Distributed, scalable and flexible monitoring system. ([Source Code](https://github.com/alerta/alerta)) `Apache-2.0` `Python`
 - [Beszel](https://beszel.dev/) - Lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions. ([Source Code](https://github.com/henrygd/beszel)) `MIT` `Go`
 - [Cacti](https://www.cacti.net) - Web-based network monitoring and graphing tool. ([Source Code](https://github.com/Cacti/cacti)) `GPL-2.0` `PHP`


### PR DESCRIPTION
## What This Adds

[Agent-SRE](https://github.com/imran-siddique/agent-sre) added alphabetically to the **Monitoring** section.

### Agent-SRE
AI-native Site Reliability Engineering framework providing:
- **SLI/SLO Engine** - Define and track service level indicators with error budget policies
- **Chaos Testing** - Automated fault injection for AI agent systems  
- **Canary Deployments** - Progressive rollout with automatic rollback on SLO violation
- **Incident Response** - Automated runbook execution and escalation

**1,071 tests** | Python 3.10+ | MIT Licensed

## Why It Belongs Here

The Monitoring section lists tools for system and application monitoring. Agent-SRE extends SRE monitoring discipline to AI agent systems - a growing infrastructure category that traditional monitoring tools don't yet cover well. It provides SLO-based monitoring, error budget tracking, and automated incident response specifically designed for autonomous agent workloads.