### PR TITLE
Add DevToolbox Cheats

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Software that does not fit in another section.
 - [Chocolatey](https://chocolatey.org/) - The package manager for Windows. ([Source Code](https://github.com/chocolatey/choco)) `Apache-2.0` `C#/PowerShell`
 - [Clonezilla](https://clonezilla.org/) - Partition and disk imaging/cloning program. ([Source Code](https://clonezilla.org/downloads/src/)) `GPL-2.0` `Perl/Shell/Other`
 - [DadaMail](https://dadamailproject.com/) - Mailing List Manager, written in Perl. ([Source Code](https://sourceforge.net/projects/dadamail/files/)) `GPL-2.0` `Perl`
+- [DevToolbox Cheats](https://github.com/dominatos/devtoolbox-cheats) - Universal Linux cheatsheet manager with native KDE Plasma 5/6 widgets and GNOME Argos integration. ([Source Code](https://github.com/dominatos/devtoolbox-cheats)) `MIT` `Shell`
 - [Fog](https://www.fogproject.org/) - Cloning/imaging solution/rescue suite. ([Source Code](https://github.com/FOGProject/fogproject)) `GPL-3.0` `PHP/Shell`
 - [phpList](https://www.phplist.org/) - Newsletter and email marketing software. ([Source Code](https://github.com/phpList/phplist3)) `AGPL-3.0` `PHP`
 


### PR DESCRIPTION
## What does it do?

Universal cross-desktop Linux cheatsheet manager for sysadmins/DevOps with:

- Native **KDE Plasma 5/6 widgets**
- **GNOME Argos** panel integration
- Dialog menus for **15+ desktop environments**
- **133 production-ready cheatsheets** (Docker, K8s, networking, databases)


## Why it belongs here

- Real productivity tool for Linux sysadmins to have fast access to cheatsheets
- Cross-desktop compatibility
- Batteries included


## Links

- Repo: https://github.com/dominatos/devtoolbox-cheats
- Screenshots: https://github.com/dominatos/devtoolbox-cheats#example-screenshots
- Release: https://github.com/dominatos/devtoolbox-cheats/releases
- MIT License