### PR TITLE
remove netdata (no longer FOSS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,6 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [Munin](https://munin-monitoring.org/) - Networked resource monitoring tool. ([Source Code](https://github.com/munin-monitoring/munin)) `GPL-2.0` `Perl/Shell`
 - [Naemon](https://www.naemon.org/) - Network monitoring tool based on the Nagios 4 core with performance enhancements and new features. ([Source Code](https://github.com/naemon/naemon-core)) `GPL-2.0` `C`
 - [Nagios](https://www.nagios.org/) - Computer system, network and infrastructure monitoring software application. ([Source Code](https://github.com/NagiosEnterprises/nagioscore)) `GPL-2.0` `C`
-- [Netdata](https://www.netdata.cloud/) - Distributed, real-time, performance and health monitoring for systems and applications. Runs on Linux, FreeBSD, and MacOS. ([Source Code](https://github.com/netdata/netdata)) `GPL-3.0` `C`
 - [NetXMS](https://www.netxms.org/) - Open Source network and infrastructure monitoring and management. ([Source Code](https://github.com/netxms/netxms)) `LGPL-3.0/GPL-3.0` `Java/C++/C`
 - [Observium Community Edition](http://www.observium.org/) - Network monitoring and management platform that provides real-time insight into network health and performance. `QPL-1.0` `PHP`
 - [openITCOCKPIT Community Edition](https://openitcockpit.io/) - Monitoring Suite featuring seamless integrations with Naemon, Checkmk, Grafana and more. ([Demo](https://demo.openitcockpit.io/), [Source Code](https://github.com/openITCOCKPIT/openITCOCKPIT)) `GPL-3.0` `deb/Docker`


### PR DESCRIPTION
* Netdata dashboard is now closed-source, proprietary software, and there is no alternative tool to exploit data returned by the netdata agent.
* The Netdata dashboard now imposes an arbitrary limit to the number of monitored nodes unless on a paid, monthly subscription plan.
* Upgrading from Netdata's previous, Free and Open-source releases silently leads to installing proprietary (since v1.41) and artifically limited (since v2.2) software.
* The new limitations and license were not mentioned in the release notes
* Netdata has been removed from Debian repositories.
* Free and Open-Source versions of Netdata, and versions without this limitation, have been removed from Netdata's APT repositories
* Netdata has repeatedly added dependencies or interactions with third-party cloud services in the dashboard (telemetry, features required a Netdata cloud subscription, ...) and misrepresenting itself as Free and Open-source software
* [[1]](https://github.com/coreinfrastructure/best-practices-badge/issues/2153), [[2]](https://github.com/netdata/netdata/pull/18125), [[3]](https://github.com/netdata/netdata/discussions/16136), [[4]](https://community.netdata.cloud/t/suddenly-local-dashboard-is-limited-to-5-nodes/7111), [[5]](https://community.netdata.cloud/t/concerned-about-the-future-of-netdata-forced-sso-cloud/5771), [[6]](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1107082), [[7]](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1106233)


