### PR TITLE
Add ADRG to Software Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Software for management of [router](https://en.wikipedia.org/wiki/Router_(comput
 
 [Operating system–level](https://en.wikipedia.org/wiki/OS-level_virtualization) virtualization.
 
+- [ADRG](https://github.com/jaldertech/adrg) - Aldertech Dynamic Resource Governor. Monitors and dynamically enforces cgroups v2 limits for Docker based on system load. ([Source Code](https://github.com/jaldertech/adrg)) `MIT` `Python`
 - [Docker Compose](https://docs.docker.com/compose/) - Define and run multi-container Docker applications. ([Source Code](https://github.com/docker/compose)) `Apache-2.0` `Go`
 - [Docker Swarm](https://docs.docker.com/engine/swarm/) - Manage cluster of Docker Engines. ([Source Code](https://github.com/moby/swarmkit)) `Apache-2.0` `Go`
 - [Docker](https://www.docker.com/) - Platform for developers and sysadmins to build, ship, and run distributed applications. ([Source Code](https://www.docker.com/community/open-source/)) `Apache-2.0` `Go`


### PR DESCRIPTION
Adding ADRG (Aldertech Dynamic Resource Governor) to the Software Containers section. It is a Python daemon designed to dynamically manage Docker containers resource limits using cgroups v2 based on system load.