### PR TITLE
Add DockProbe - lightweight Docker monitoring with anomaly detection & Telegram alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [cadvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers. `Apache-2.0` `Go`
 - [checkmk](https://checkmk.com/) - Comprehensive solution for monitoring of applications, servers, and networks. ([Source Code](https://github.com/Checkmk/checkmk)) `GPL-2.0` `Python/PHP`
 - [dashdot](https://github.com/MauriceNino/dashdot) - A simple, modern server dashboard for smaller private servers. ([Demo](https://dash.mauz.dev/)) `MIT` `Nodejs/Docker`
+- [DockProbe](https://github.com/deep-on/dockprobe) - Lightweight Docker container monitoring dashboard with 6 anomaly detection rules, Telegram alerts, and 16 automated security scans. Runs as a single container with zero config. ([Source Code](https://github.com/deep-on/dockprobe)) `Apache-2.0` `Docker/Python`
 - [EdMon](https://github.com/Edraens/EdMon) - A command-line monitoring application helping you to check that your hosts and services are available, with notifications support. `MIT` `Java`
 - [eZ Server Monitor](https://www.ezservermonitor.com) - A lightweight and simple dashboard monitor for Linux, available in Web and Bash application. ([Source Code](https://github.com/shevabam/ezservermonitor-web)) `GPL-3.0` `PHP/Shell`
 - [glances](https://nicolargo.github.io/glances/) - Open-source, cross-platform real-time monitoring tool with CLI and web dashboard interfaces and many exporting options. ([Source Code](https://github.com/nicolargo/glances)) `GPL-3.0` `Python`


### PR DESCRIPTION
## What is DockProbe?

[DockProbe](https://github.com/deep-on/dockprobe) is a lightweight Docker container monitoring dashboard that runs as a single container with zero configuration.

### Key Features

- 📊 Real-time container metrics (CPU, memory, network, disk)
- 🔍 6 anomaly detection rules (CPU spike, memory overflow, restart loop, network surge, disk pressure, temperature)
- 📱 Telegram alerts with 30-minute cooldown
- 🔒 16 automated security scans every 5 minutes
- 🐳 One-command setup, no external database, no agents
- ⚡ ~50MB RAM footprint, only 4 Python packages

### Why it fits the Monitoring section

DockProbe is specifically focused on Docker container monitoring with anomaly detection and security scanning — filling a lightweight niche between full Prometheus/Grafana stacks and simple dashboard tools.

```bash
docker run -d -p 8000:8000 -v /var/run/docker.sock:/var/run/docker.sock deeponinc/dockprobe
```

- License: Apache-2.0
- Language: Python
- Also listed in: [awesome-docker](https://github.com/veggiemonk/awesome-docker)