### PR TITLE
Add BillingWatch to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface. ([Source Code](https://github.com/opinkerfi/adagios)) `AGPL-3.0` `Docker/Python`
 - [Alerta](https://alerta.io/) - Distributed, scalable and flexible monitoring system. ([Source Code](https://github.com/alerta/alerta)) `Apache-2.0` `Python`
 - [Beszel](https://beszel.dev/) - Lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions. ([Source Code](https://github.com/henrygd/beszel)) `MIT` `Go`
+- [BillingWatch](https://github.com/rmbell09-lang/BillingWatch) - Automated Stripe billing anomaly detection. Monitors webhook events and alerts on charge failures, duplicates, and revenue drops. `MIT` `Python`
 - [Cacti](https://www.cacti.net) - Web-based network monitoring and graphing tool. ([Source Code](https://github.com/Cacti/cacti)) `GPL-2.0` `PHP`
 - [cadvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers. `Apache-2.0` `Go`
 - [cState](https://cstate.netlify.app/) - Static status page for hyperfast Hugo. Clean design, minimal JS, super light HTML/CSS, high customization, optional admin panel, read-only API, IE8+. ([Demo](https://cstate.mnts.lt/), [Source Code](https://github.com/cstate/cstate))


### PR DESCRIPTION
## BillingWatch

Adding [BillingWatch](https://github.com/rmbell09-lang/BillingWatch) to the Monitoring & Status Pages section.

**What it is:** A self-hosted billing anomaly detection tool that monitors Stripe webhook events and alerts on charge failures, duplicates, fraud spikes, and revenue drops.

- **License:** MIT
- **Language:** Python (FastAPI)
- **Docker:** Yes
- **Self-hosted:** Yes
- **Stars:** 10+
- **Active:** Yes (last commit within 30 days)

Fits the monitoring category as it monitors billing/financial events from Stripe.