### PR TITLE
Add VictoriaMetrics to Metrics & Metric Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ _Related: [Databases](#databases), [Monitoring](#monitoring)_
 - [Statsd](https://github.com/etsy/statsd/) - Daemon that listens for statistics like counters and timers, sent over UDP or TCP, and sends aggregates to one or more pluggable backend services. `MIT` `Nodejs`
 - [tcollector](http://opentsdb.net/docs/build/html/user_guide/utilities/tcollector.html) - Gathers data from local collectors and pushes the data to OpenTSDB. ([Source Code](https://github.com/OpenTSDB/tcollector/)) `LGPL-3.0/GPL-3.0` `Python`
 - [Telegraf](https://github.com/influxdata/telegraf) - Plugin-driven server agent for collecting, processing, aggregating, and writing metrics. `MIT` `Go`
-
+- [VictoriaMetrics](https://victoriametrics.com/) - Fast, cost-effective time series database and monitoring solution; drop-in replacement for Prometheus with PromQL/MetricsQL support. ([Source Code (https://github.com/VictoriaMetrics/VictoriaMetrics)) `Apache-2.0` `Go`
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -459,7 +459,10 @@ _Related: [Databases](#databases), [Monitoring](#monitoring)_
 - [Statsd](https://github.com/etsy/statsd/) - Daemon that listens for statistics like counters and timers, sent over UDP or TCP, and sends aggregates to one or more pluggable backend services. `MIT` `Nodejs`
 - [tcollector](http://opentsdb.net/docs/build/html/user_guide/utilities/tcollector.html) - Gathers data from local collectors and pushes the data to OpenTSDB. ([Source Code](https://github.com/OpenTSDB/tcollector/)) `LGPL-3.0/GPL-3.0` `Python`
 - [Telegraf](https://github.com/influxdata/telegraf) - Plugin-driven server agent for collecting, processing, aggregating, and writing metrics. `MIT` `Go`
-- [VictoriaMetrics](https://victoriametrics.com/) - Fast, cost-effective time series database and monitoring solution; drop-in replacement for Prometheus with PromQL/MetricsQL support. ([Source Code (https://github.com/VictoriaMetrics/VictoriaMetrics)) `Apache-2.0` `Go`
+- [VictoriaMetrics](https://victoriametrics.com/) - Fast, cost-effective time series database and monitoring solution; drop-in replacement for Prometheus with PromQL/MetricsQL support. ([Source Code](https://github.com/VictoriaMetrics/VictoriaMetrics)) `Apache-2.0` `Go`
+
+
+
 
 ### Miscellaneous
 


### PR DESCRIPTION
Hi maintainers, hope you're doing well!

I noticed VictoriaMetrics is missing from the Metrics & Metric Collection section and thought it'd be a great addition. It's one of the most widely used tools in the Prometheus ecosystem — 16,500+ stars, production deployments at Grammarly, Roblox, Spotify and others, and it's a single binary with no external dependencies which sysadmins tend to love.

Worth noting: VictoriaMetrics does have an Enterprise tier with a separate license, but both the single-node and cluster community editions are fully Apache-2.0 with no feature-gating on the core functionality.

- [x] Your additions are Free software
- [x] Software you are submitting is not your own
- [x] Submit one item per pull request
- [x] Format is correct (description under 250 chars, sentence case)
- [x] Additions are inserted preserving alphabetical order
- [x] Additions are not already listed at awesome-selfhosted
- [x] The Language tag is the main server-side requirement
- [x] You have searched the repository for any relevant issues or PRs, including closed ones
- [x] Any category you are creating has the minimum requirement of 3 items
- [x] Any software project you are adding to the list is actively maintained
- [x] The pull request title is informative

**Why is it awesome?**
VictoriaMetrics is one of the most widely deployed open-source time series databases in the Prometheus ecosystem. It offers significantly better performance and compression than vanilla Prometheus, supports PromQL natively, and ships as a single binary with zero external dependencies — making it extremely straightforward to operate.

**Have you used it? For how long?**
Yes, approximately one year.

**Is this in a personal or professional setup?**
Both homelab monitoring and professional infrastructure observability.

**How many devices/users/services/... do you manage with it?**
Scraping metrics from ~20 services and infrastructure nodes.

**Biggest pros/cons compared to other solutions?**
Pros: dramatically lower memory and disk usage compared to Prometheus, single binary, fully PromQL-compatible, excellent documentation. Cons: the clustering mode and some advanced features are enterprise-only, though