### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Software for management of [router](https://en.wikipedia.org/wiki/Router_(comput
 - [Docker](https://www.docker.com/) - Platform for developers and sysadmins to build, ship, and run distributed applications. ([Source Code](https://www.docker.com/community/open-source/)) `Apache-2.0` `Go`
 - [LXC](https://linuxcontainers.org/lxc/) - Userspace interface for the Linux kernel containment features. ([Source Code](https://github.com/lxc/lxc)) `GPL-2.0` `C`
 - [LXD](https://linuxcontainers.org/lxd/) - Container "hypervisor" and a better UX for LXC. ([Source Code](https://github.com/lxc/lxd)) `Apache-2.0` `Go`
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container management tool built natively on Apple's Containerization framework for macOS. ([Source Code](https://github.com/us/mocker)) `AGPL-3.0` `Swift`
 - [OpenVZ](https://openvz.org) - Container-based virtualization for Linux. ([Source Code](https://src.openvz.org/projects/OVZ)) `GPL-2.0` `C`
 - [Podman](https://podman.io) - Daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Containers can either be run as root or in rootless mode. Simply put: `alias docker=podman`. ([Source Code](https://github.com/containers/podman)) `Apache-2.0` `Go`
 - [Portainer Community Edition](https://www.portainer.io/) - Simple management UI for Docker. ([Source Code](https://github.com/portainer/portainer)) `Zlib` `Go`


### PR DESCRIPTION
## What is Mocker?

[Mocker](https://github.com/us/mocker) is a Docker-compatible container management tool built natively on Apple's Containerization framework. It provides the same Docker CLI commands and flags (`mocker run`, `ps`, `stop`, `build`, `compose`, `stats`) running natively on macOS without Docker Desktop.

- **Open Source:** AGPL-3.0
- **Platform:** macOS (Apple Silicon)
- **Language:** Swift
- **GitHub:** https://github.com/us/mocker