### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Software for management of [router](https://en.wikipedia.org/wiki/Router_(comput
 - [Docker](https://www.docker.com/) - Platform for developers and sysadmins to build, ship, and run distributed applications. ([Source Code](https://www.docker.com/community/open-source/)) `Apache-2.0` `Go`
 - [LXC](https://linuxcontainers.org/lxc/) - Userspace interface for the Linux kernel containment features. ([Source Code](https://github.com/lxc/lxc)) `GPL-2.0` `C`
 - [LXD](https://linuxcontainers.org/lxd/) - Container "hypervisor" and a better UX for LXC. ([Source Code](https://github.com/lxc/lxd)) `Apache-2.0` `Go`
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. ([Source Code](https://github.com/us/mocker)) `AGPL-3.0` `Swift`
 - [OpenVZ](https://openvz.org) - Container-based virtualization for Linux. ([Source Code](https://src.openvz.org/projects/OVZ)) `GPL-2.0` `C`
 - [Podman](https://podman.io) - Daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Containers can either be run as root or in rootless mode. Simply put: `alias docker=podman`. ([Source Code](https://github.com/containers/podman)) `Apache-2.0` `Go`
 - [Portainer Community Edition](https://www.portainer.io/) - Simple management UI for Docker. ([Source Code](https://github.com/portainer/portainer)) `Zlib` `Go`


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is a Docker-compatible container CLI for macOS, built natively on Apple's Containerization framework.

- **License:** AGPL-3.0
- **Language:** Swift
- **Category:** Software Containers

Mocker provides full Docker CLI compatibility (111 commands with all flags) while running containers natively on macOS using Apple's virtualization stack. It supports Docker Compose, container lifecycle management, networking, and volumes — all without requiring Docker Desktop.