### PR TITLE
Add Admirarr — unified CLI for Jellyfin/Plex + *Arr fleet status & diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Monitoring software.
 
 _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 
+- [Admirarr](https://github.com/maxtechera/admirarr) - Unified CLI for Jellyfin/Plex + \*Arr media server stacks — fleet status, health diagnostics, and automated repair from a single terminal. ([Source Code](https://github.com/maxtechera/admirarr)) `MIT` `Go`
 - [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface. ([Source Code](https://github.com/opinkerfi/adagios)) `AGPL-3.0` `Docker/Python`
 - [Alerta](https://alerta.io/) - Distributed, scalable and flexible monitoring system. ([Source Code](https://github.com/alerta/alerta)) `Apache-2.0` `Python`
 - [Beszel](https://beszel.dev/) - Lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions. ([Source Code](https://github.com/henrygd/beszel)) `MIT` `Go`


### PR DESCRIPTION
## What is Admirarr?

[Admirarr](https://github.com/maxtechera/admirarr) is a unified CLI for Jellyfin/Plex + \*Arr media server stacks.

**One binary, 26 commands, JSON output everywhere.** Monitor fleet status, run health diagnostics across 15 categories/34 checks, and operate your entire media automation stack from a single terminal.

### Why it belongs in Monitoring & Status Pages

Admirarr's core sysadmin value is diagnostics and health monitoring for complex multi-service homelab/self-hosted stacks. The `doctor` command runs 34 automated checks (connectivity, API health, disk space, queue health, config validation) across all services and suggests repairs.

### Key capabilities
- `admirarr status` — Live TUI fleet dashboard (all services, versions, health)
- `admirarr doctor` — 15 diagnostic categories, 34 checks, AI-powered repair suggestions
- `admirarr doctor --fix` — Automated remediation for common issues
- `admirarr setup` — 12-phase automated deployment (zero to full stack in ~15 min)
- JSON output on all commands — composable with grep/jq/alerting pipelines
- Covers Jellyfin, Plex, Radarr, Sonarr, Prowlarr, qBittorrent, Gluetun, Seerr, Bazarr, FlareSolverr + 14 optional services
- Single static binary, zero runtime dependencies

### Technical details
- **Language**: Go (single static binary)
- **License**: MIT
- **Repo**: https://github.com/maxtechera/admirarr
- **Install**: `curl -fsSL https://get.admirarr.dev | sh`