### PR TITLE
Add amneziawg-installer to VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ Virtualization software.
 
 VPN software.
 
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - One-command installer for AmneziaWG 2.0 VPN with DPI-resistant obfuscation on Ubuntu and Debian. `MIT` `Shell`
 - [DefGuard](https://defguard.net/) - True enterprise WireGuard with MFA/2FA and SSO. ([Source Code](https://github.com/DefGuard)) `Apache-2.0` `Rust`
 - [Dockovpn](https://dockovpn.io) - Out-of-the-box stateless dockerized OpenVPN server which starts in less than 2 seconds. ([Source Code](https://github.com/dockovpn/dockovpn)) `GPL-2.0` `Docker`
 - [Firezone](https://www.firezone.dev/) - WireGuard based VPN Server and Firewall. ([Source Code](https://github.com/firezone/firezone)) `Apache-2.0` `Docker`


### PR DESCRIPTION
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software)
- [x] Software you are submitting is not your own, unless you have a healthy ecosystem with a few contributors (which aren't your sock puppet accounts).
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] Format your submission as follows, where `Demo` and `Clients` are optional.
- [x] Additions are inserted preserving alphabetical order.
- [x] Additions are not already listed at [awesome-selfhosted](https://awesome-selfhosted.net)
- [x] The `Language` tag is the main **server-side** requirement for the software.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-foss/awesome-sysadmin/issues) or [PRs](https://github.com/awesome-foss/awesome-sysadmin/pulls), including closed ones.
- [x] Any software project you are adding to the list is actively maintained.
- [x] The pull request title is informative, unlike "Update README.md".

--------------

- **Why is it awesome?**

AmneziaWG is a WireGuard fork with protocol-level obfuscation that bypasses DPI. Setting it up manually is painful (DKMS module, obfuscation params, firewall rules). This script automates the entire process — one command from a clean VPS to a working VPN server. Similar to how Dockovpn wraps OpenVPN in Docker, this wraps AmneziaWG in a Bash installer.

- **Have you used it? For how long?**

Yes, I'm the author. Running it on production VPS since late 2025. 160+ stars, 16 forks, active contributors filing issues and submitting patches (kernel deadlock analysis, Debian mawk compat fixes, batch operations).

- **Is this in a personal or professional setup?**

Personal — self-hosted VPN for family use on cheap VPS instances.

- **How many devices/users/services/... do you manage with it?**

3 servers (Ubuntu 24.04, Debian 12, Debian 13), ~15 clients across them.

- **Biggest pros/cons compared to other solutions?**

Pros: one command, pure Bash (no Docker/Ansible), survives reboots mid-install (state machine), generates QR codes and vpn:// URIs for mobile import, supports AmneziaWG 2.0 with CPS protocol mimicry.

Cons: Ubuntu/Debian only (no RHEL/Fedora), no web UI, single-purpose (assumes dedicated VPN server).

- **Any other comments?**

Previous PR #688 was declined as "too young" at ~100 stars. The project has since grown to 160+ stars with an active community (issues #24-#31, 5 contributors). Dockovpn (OpenVPN Docker wrapper) sets a precedent for installer/wrapper tools in this section.