### PR TITLE
Add Crontiq to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [cState](https://cstate.netlify.app/) - Static status page for hyperfast Hugo. Clean design, minimal JS, super light HTML/CSS, high customization, optional admin panel, read-only API, IE8+. ([Demo](https://cstate.mnts.lt/), [Source Code](https://github.com/cstate/cstate))
 - [checkmk](https://checkmk.com/) - Comprehensive solution for monitoring of applications, servers, and networks. ([Demo]([Source Code](https://github.com/Checkmk/checkmk)) `GPL-2.0` `Python/PHP`
 - [CheckCle](https://checkcle.io) - Seamless, real-time monitoring of full-stack systems, applications, and infrastructure. ([Source Code](https://github.com/operacle/checkcle)) `MIT` `Docker`
+- [Crontiq](https://crontiq.io) - Cron job monitoring with automatic JSON payload analysis, anomaly detection (moving average + 2σ), and public SVG status badges. Free tier includes 20 monitors. `⊘ Proprietary`
 - [dashdot](https://github.com/MauriceNino/dashdot) - A simple, modern server dashboard for smaller private servers. ([Demo](https://dash.mauz.dev/)) `MIT` `Nodejs/Docker`
 - [EdMon](https://github.com/Edraens/EdMon) - A command-line monitoring application helping you to check that your hosts and services are available, with notifications support. `MIT` `Java`
 - [eZ Server Monitor](https://www.ezservermonitor.com) - A lightweight and simple dashboard monitor for Linux, available in Web and Bash application. ([Source Code](https://github.com/shevabam/ezservermonitor-web)) `GPL-3.0` `PHP/Shell`


### PR DESCRIPTION
Crontiq is a cron job monitoring service that goes beyond simple heartbeat checks by automatically extracting metrics from JSON payloads and detecting anomalies.

**Key features:**
- Heartbeat/dead man's switch monitoring
- Auto JSON payload parsing (flattens nested objects, extracts all numerics)
- Zero-config anomaly detection (moving average + 2σ)
- Public SVG badges with live data for GitHub READMEs
- 20 monitors free forever

Website: https://crontiq.io

It fills a gap in the Monitoring section — currently there's no tool listed specifically for cron job/heartbeat monitoring with payload analysis.