### PR TITLE
Add WgDashboard++ to VPN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ VPN software.
 - [SoftEther](https://www.softether.org/) - Multi-protocol software VPN with advanced features. ([Source Code](https://github.com/SoftEtherVPN/SoftEtherVPN/)) `Apache-2.0` `C`
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN. `LGPL-2.1` `Python`
 - [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux. ([Source Code](https://github.com/strongswan/strongswan)) `GPL-2.0` `C`
+- [WgDashboard++](https://github.com/polumish/wgdashboard-plus-plus) - Web dashboard to manage WireGuard servers and peers (fork of WGDashboard) with client self-service portal, dual-column peer view, and OPNsense integration. `Apache-2.0` `Python/Docker`
 - [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto. ([Source Code](https://www.wireguard.com/repositories/)) `GPL-2.0` `C`
 
 


### PR DESCRIPTION
## What

Adds WgDashboard++ to the VPN section — a fork of WGDashboard with additional features for managing WireGuard networks.

## Project info

- **Repo:** https://github.com/polumish/wgdashboard-plus-plus
- **License:** Apache-2.0 (same as upstream)
- **Stack:** Python + Vue, Docker image published on ghcr.io
- **First release:** v1.0 (2026-04-04)

## Why a separate entry from upstream WGDashboard

WGDashboard is not currently listed. This fork adds operational features for multi-tenant environments (client portal, density settings, dual-column peer view, OPNsense integration) that justify a distinct entry focused on multi-admin sysadmin workflows.

## Entry placed

In VPN section, alphabetically between `strongSwan` and `WireGuard`.

---

Please let me know if any changes are needed. Thanks for maintaining this list!