### PR TITLE
Add TiredVPN to VPN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ VPN software.
 - [SoftEther](https://www.softether.org/) - Multi-protocol software VPN with advanced features. ([Source Code](https://github.com/SoftEtherVPN/SoftEtherVPN/)) `Apache-2.0` `C`
 - [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN. `LGPL-2.1` `Python`
 - [strongSwan](https://www.strongswan.org/) - Complete IPsec implementation for Linux. ([Source Code](https://github.com/strongswan/strongswan)) `GPL-2.0` `C`
+- [TiredVPN](https://github.com/tiredvpn/tiredvpn) - DPI-resistant VPN with 20+ obfuscation strategies and adaptive fallback for censored networks. ([Source Code](https://github.com/tiredvpn/tiredvpn)) `AGPL-3.0` `Go/Docker`
 - [WireGuard](https://www.wireguard.com/) - Very fast VPN based on elliptic curve and public key crypto. ([Source Code](https://www.wireguard.com/repositories/)) `GPL-2.0` `C`
 
 


### PR DESCRIPTION
## What is TiredVPN?

A self-hosted VPN server and client designed to bypass Deep Packet Inspection (DPI) in countries like Russia, China, and Iran.

## Why add it?

Unlike traditional VPN solutions in this list (WireGuard, OpenVPN, SoftEther), TiredVPN specifically targets censorship evasion:

- 20+ built-in obfuscation strategies (REALITY, QUIC Salamander, HTTP/2 Stego, WebSocket, traffic morphing, protocol confusion)
- Adaptive fallback engine: automatically switches strategies when blocked
- Multiplexed connections over smux
- Server + Linux client + Android client

## Checklist

- [x] Open source (AGPL-3.0)
- [x] Self-hostable
- [x] Actively maintained
- [x] Written in Go
- [x] Docker support
- [x] Entry follows the existing format
- [x] Alphabetical order maintained

Links:
- Server/Client: https://github.com/tiredvpn/tiredvpn
- Android: https://github.com/tiredvpn/tiredvpn-android