### PR TITLE
Add web-based DNS diagnostic tools to DNS - Control Panels section

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ _See also: [awesome-selfhosted/DNS](https://awesome-selfhosted.net/tags/dns.html
 - [nsupdate.info](https://www.nsupdate.info/) - Dynamic DNS service. ([Demo](https://www.nsupdate.info/account/register/), [Source Code](https://github.com/nsupdate-info/nsupdate.info)) `BSD-3-Clause` `Python`
 - [octoDNS](https://github.com/github/octodns) - DNS as code - Tools for managing DNS across multiple providers. `MIT` `Python`
 - [Poweradmin](https://www.poweradmin.org/) - Web-based DNS control panel for PowerDNS server. ([Source Code](https://github.com/poweradmin/poweradmin)) `GPL-3.0` `PHP`
+- [DNSChecker](https://dnschecker.org) - DNS propagation checker that queries 100+ DNS servers worldwide to verify record changes. `Proprietary` `Web`
+- [IntoDNS](https://intodns.com) - DNS health and mail server configuration checker that reports misconfigurations and best-practice issues. `Proprietary` `Web`
+- [iptoolspro.com](https://iptoolspro.com) - Browser-based network diagnostic tools: IP lookup, DNS records, port checker, WHOIS, VPN leak test, IP blacklist check. `Proprietary` `Web`
+- [MXToolbox](https://mxtoolbox.com) - Free online tools to investigate MX records, DNS propagation, blacklists, SMTP diagnostics, and network lookups. `Proprietary` `Web`
 - [SPF Toolbox](https://spftoolbox.com) - Application to look up DNS records such as SPF, MX, Whois, and more. ([Source Code](https://github.com/charlesabarnes/SPFtoolbox)) `MIT` `PHP`
 
 


### PR DESCRIPTION
Adds 4 missing web-based DNS and network diagnostic tools to the DNS - Control Panels & Domain Management section, in alphabetical order alongside the existing SPF Toolbox entry.

**Added tools:**
- **DNSChecker** — DNS propagation checker querying 100+ global servers
- **IntoDNS** — DNS health and mail server configuration validator
- **iptoolspro.com** — Browser-based diagnostics: IP lookup, DNS records, port checker, WHOIS, VPN leak test, IP blacklist check
- **MXToolbox** — MX records, DNS propagation, blacklist lookup, SMTP diagnostics

All are free, no-install browser tools — a category currently underrepresented in this section despite SPF Toolbox being a precedent for this type of tool.