### PR TITLE
Add Kite — self-hostable webhook relay for monitoring (Monitoring & Status Pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 
 - [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface. ([Source Code](https://github.com/opinkerfi/adagios)) `AGPL-3.0` `Docker/Python`
 - [Alerta](https://alerta.io/) - Distributed, scalable and flexible monitoring system. ([Source Code](https://github.com/alerta/alerta)) `Apache-2.0` `Python`
+- [Kite](https://getkite.sh/) - Self-hostable webhook relay for monitoring and alerting. Receives webhooks from Stripe, GitHub, Slack, verifies signatures, normalizes to CloudEvents, and delivers to local monitoring tools or agent runtimes. ([Source Code](https://github.com/lommaj/kite)) `MIT` `Rust/Docker`
 - [Beszel](https://beszel.dev/) - Lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions. ([Source Code](https://github.com/henrygd/beszel)) `MIT` `Go`
 - [Cacti](https://www.cacti.net) - Web-based network monitoring and graphing tool. ([Source Code](https://github.com/Cacti/cacti)) `GPL-2.0` `PHP`
 - [cadvisor](https://github.com/google/cadvisor) - Analyzes resource usage and performance characteristics of running containers. `Apache-2.0` `Go`


### PR DESCRIPTION
Hi! I'd like to add Kite to the Monitoring & Status Pages section.

**What it is**: Kite is a self-hostable webhook relay for monitoring and alerting. It receives webhooks from services like Stripe, GitHub, and Slack, verifies their signatures, normalizes them to CloudEvents format, and delivers them to local monitoring tools or agent runtimes.

**Why it fits Monitoring**:
- Receive and process monitoring alerts via webhooks
- Built-in signature verification (no false positives from spoofed webhooks)
- CloudEvents standardization for interoperability with monitoring stacks
- Sub-10ms latency for real-time alerting
- Self-hostable (single binary or Docker)

**Use cases**:
- Monitor Stripe payment events for revenue tracking
- Receive GitHub deployment webhooks for CI/CD monitoring
- Process Slack alerts and route to incident management tools
- Fan-in multiple webhook sources to a single monitoring dashboard

**Links**:
- Website: https://getkite.sh
- GitHub: https://github.com/lommaj/kite
- Docs: https://getkite.sh/docs

Thanks for maintaining this list!