### PR TITLE
Add Packet Test Bundle to Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ Troubleshooting tools.
 - [grml](https://grml.org) - Bootable Debian Live CD with powerful CLI tools. ([Source Code](https://github.com/grml/)) `GPL-3.0` `Shell`
 - [mitmproxy](https://mitmproxy.org/) - A Python tool used for intercepting, viewing and modifying network traffic. Invaluable in troubleshooting certain problems. ([Source Code](https://github.com/mitmproxy/mitmproxy)) `MIT` `Python`
 - [mtr](https://www.bitwizard.nl/mtr/) - Network utility that combines traceroute and ping. ([Source Code](https://github.com/traviscross/mtr)) `GPL-2.0` `C`
+- [Packet Test Bundle](https://github.com/galenthas/packet-test-bundle) - Native Windows GUI bundling iperf2, iperf3, tshark, and ping for network throughput and latency testing. ([Source Code](https://github.com/galenthas/packet-test-bundle)) `MIT` `C++`
 - [Sysdig](https://www.sysdig.com/) - Capture system state and activity from a running Linux instance, then save, filter and analyze. ([Source Code](https://github.com/draios/sysdig)) `Apache-2.0` `Docker/Lua/C`
 - [Wireshark](https://www.wireshark.org/) - The world's foremost network protocol analyzer. ([Source Code](https://gitlab.com/wireshark/wireshark)) `GPL-2.0` `C`
 


### PR DESCRIPTION
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software)
- [x] Submit one item per pull request.
- [x] Format your submission as follows.
- [x] Additions are inserted preserving alphabetical order.
- [x] Additions are not already listed at [awesome-selfhosted](https://awesome-selfhosted.net)
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software project you are adding to the list is actively maintained.
- [x] The pull request title is informative.

---

- **Why is it awesome?**

It combines three common network troubleshooting CLI tools (iperf2, iperf3, tshark) into a single native GUI with live throughput and latency charts. Instead of switching between terminal windows and parsing text output, you get real-time ImPlot graphs and one-click server/client mode switching. It is the only open-source tool that bundles both iperf bandwidth testing and tshark packet capture in a single interface.

- **Have you used it? For how long?**

Yes, since the initial release. Used for LAN throughput testing and packet capture during network troubleshooting.

- **Is this in a personal or professional setup?**

Both — personal home network testing and professional network diagnostics.

- **How many devices/users/services/... do you manage with it?**

Used across a small fleet of Windows workstations for point-to-point network testing.

- **Biggest pros/cons compared to other solutions?**

Pros: Single portable .exe, no Java runtime (unlike jperf), combines iperf + tshark in one UI, live charts.
Cons: Windows-only, relatively new project.

- **Any other comments?**

MIT licensed, C++17, builds with CMake/Ninja. Bundles iperf2, iperf3, and tshark so there are no external dependencies beyond Npcap for packet capture.