### PR TITLE
Add AIWatch to Monitoring & Status Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Monitoring software.
 _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 
 - [Adagios](http://adagios.org/) - Web based Nagios interface for configuration and monitoring (replacement to the standard interface), and a REST interface. ([Source Code](https://github.com/opinkerfi/adagios)) `AGPL-3.0` `Docker/Python`
+- [AIWatch](https://ai-watch.dev) - Real-time status dashboard that monitors 30 third-party AI services (Claude, OpenAI, Gemini, etc.) with AI-powered incident analysis and early outage detection vs official status pages. ([Source Code](https://github.com/bentleypark/aiwatch)) `AGPL-3.0` `Cloudflare Workers`
 - [Alerta](https://alerta.io/) - Distributed, scalable and flexible monitoring system. ([Source Code](https://github.com/alerta/alerta)) `Apache-2.0` `Python`
 - [Beszel](https://beszel.dev/) - Lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions. ([Source Code](https://github.com/henrygd/beszel)) `MIT` `Go`
 - [Cacti](https://www.cacti.net) - Web-based network monitoring and graphing tool. ([Source Code](https://github.com/Cacti/cacti)) `GPL-2.0` `PHP`


### PR DESCRIPTION
Adds **AIWatch** to the `Monitoring & Status Pages` section (alphabetical position between Adagios and Alerta).

**AIWatch** — https://ai-watch.dev

Real-time status dashboard for 30 third-party AI services (Claude, OpenAI, Gemini, Mistral, Groq, and more) with:

- **Third-party status monitoring** — polls provider status pages + directly probes API endpoints every 5 minutes. Produces a single dashboard + API for consumers of external AI services.
- **AI-powered incident analysis** — hybrid Gemma 4 26B (Cloudflare Workers AI) + Claude Sonnet fallback. Summarizes cause + estimated recovery.
- **Early detection** — surfaces "Detection Lead" when probe RTT anomalies precede official status page acknowledgments.
- **Discord/Slack webhooks** — alerts with AI analysis attached.
- **Reliability scoring** — 0-100 composite (uptime + incidents + recovery + responsiveness).
- **Self-hostable** on Cloudflare Workers (free tier sufficient for typical load); also runs as a hosted service at ai-watch.dev.

License: AGPL-3.0
Stack: Cloudflare Workers + KV + Workers AI (React 19 frontend)

### Entry format

`- [AIWatch](https://ai-watch.dev) - Real-time status dashboard that monitors 30 third-party AI services (Claude, OpenAI, Gemini, etc.) with AI-powered incident analysis and early outage detection vs official status pages. ([Source Code](https://github.com/bentleypark/aiwatch)) ``AGPL-3.0`` ``Cloudflare Workers``

### Placement rationale

Listed alongside similar third-party-service status dashboards already in this section: **Gatus** (automated service health dashboard), **Kener** (status page with incident management), **OneUptime** (monitoring online services), **cState** (static status page generator). AIWatch is domain-specific (AI services) rather than general HTTP monitoring — feel free to reject if the list prefers general-purpose tools only.