### PR TITLE
Add TimeNest under Backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ _See also: [Restic's list of Linux backup software](https://github.com/restic/ot
 - [Restic](https://restic.net/) - Easy, fast, verifiable, secure and efficient remote backup tool. ([Source Code](https://github.com/restic/restic)) `BSD-2-Clause` `Go`
 - [Rsnapshot](https://rsnapshot.org/) - Filesystem snapshot utility based on rsync. ([Source Code](https://github.com/rsnapshot/rsnapshot)) `GPL-2.0` `Perl`
 - [Shield](https://github.com/starkandwayne/shield) - A pluggable architecture for backup and restore of database systems. `MIT` `Go`
+- [TimeNest](https://github.com/momenbasel/timenest) - Self-hosted network Time Machine server that turns a Mac mini, Raspberry Pi, or any Linux host into a Time Capsule replacement for every Mac on the LAN. Docker stack: Samba with `vfs_fruit`, Avahi for Bonjour discovery, FastAPI admin UI with per-user quotas and Prometheus metrics. `MIT` `Docker/Python`
 - [UrBackup](https://www.urbackup.org/) - Client/Server Open Source Network Backup for Windows, MacOS and Linux. ([Source Code](https://github.com/uroni/urbackup_backend)) `AGPL-3.0` `C/C++`
 
 ### Build and software organization tools


### PR DESCRIPTION
Hi, adding [TimeNest](https://github.com/momenbasel/timenest) under the Backups section.

## What it is

TimeNest is a self-hosted network Time Machine server for macOS. Three-container Docker stack:

- Samba 4.18 with \`vfs_fruit\` - per-user Time Machine shares with quota enforcement
- Avahi - advertises the server over Bonjour as a \`TimeCapsule8,119\` so Finder picks it up natively
- FastAPI + Jinja + htmx admin UI on port 8080 with Prometheus \`/metrics\`

Runs on Mac mini, Raspberry Pi 4/5, and generic \`linux/amd64\` or \`linux/arm64\` home servers via a single \`docker compose up -d\`.

## Why it fits the Backups section

It is strictly backup software: the only job is to be the Time Machine target for Macs on a LAN. Comparable entries already listed (UrBackup, Minarca) cover similar multi-client network-backup territory for Windows/Linux/macOS.

## License

MIT, no telemetry, no cloud dependency. Source at https://github.com/momenbasel/timenest

Happy to adjust the entry wording if the format needs to change.