### PR TITLE
Add gotify-commander to Control Panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Web hosting and server or service control panels.
 
 - [Ajenti](https://ajenti.org/) - Control panel for Linux and BSD. ([Source Code](https://github.com/ajenti/ajenti)) `MIT` `Python/Shell`
 - [Cockpit](https://cockpit-project.org/) - Web-based graphical interface for servers. ([Source Code](https://github.com/cockpit-project/cockpit)) `LGPL-2.1` `C`
+- [gotify-commander](https://github.com/drolosoft/gotify-commander) - Bidirectional Gotify plugin to manage servers from your phone — restart services, check system health, view logs via notifications or web control panel. ([Source Code](https://github.com/drolosoft/gotify-commander)) `MIT` `Go`
 - [Froxlor](https://froxlor.org/) - Lightweight server management software with Nginx and PHP-FPM support. ([Source Code](https://github.com/Froxlor/Froxlor/)) `GPL-2.0` `PHP`
 - [HestiaCP](https://hestiacp.com/) - Web server control panel (fork of VestaCP). ([Demo](https://demo.hestiacp.com:8083/login/), [Source Code](https://github.com/hestiacp/hestiacp)) `GPL-3.0` `PHP/Shell/Other`
 - [ISPConfig](https://www.ispconfig.org) - Manage Linux servers directly through your browser. ([Source Code](https://git.ispconfig.org/ispconfig/ispconfig3)) `BSD-3-Clause` `PHP`


### PR DESCRIPTION
Add [gotify-commander](https://github.com/drolosoft/gotify-commander) — a bidirectional Gotify plugin that lets you manage servers from your phone.

Tap `restart nginx` from the Gotify app, get `✅ nginx restarted` as a notification. Also serves a web control panel. 23 commands, multi-machine support, YAML config.

- MIT license, Go
- Pre-built .so for linux/amd64
- Works with Gotify 2.6.x