### PR TITLE
Add ci-doctor under Continuous Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ VPN software.
 
 
 --------------------
+- [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) `MIT` `Node` - Audits GitHub Actions workflows for cost waste, security gaps, and reliability issues. 16 rules. SARIF + PR comment integration.
 
 ## List of Licenses
 


### PR DESCRIPTION
### What this adds

> - [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) `MIT` `Node` - Audits GitHub Actions workflows for cost waste, security gaps, and reliability issues. 16 rules. SARIF + PR comment integration.

### Why

depmedic ships a family of CI cost+security auditors covering GitHub, GitLab, Bitbucket, Azure Pipelines, and CircleCI. Each is a single-binary `npx` invocation, MIT, no telemetry, with SARIF + PR comment integration. They are well-tested (3-5 `node --test` suites each), versioned, and actively maintained.

### Conformance

- One line per entry in alphabetical order within the section
- Description starts with a verb (Audit / Audits)
- Trailing period on the description
- Link target is the canonical repo URL

Happy to adjust wording, ordering, or section placement; ping me on this PR.

---

If you'd rather decline, no hard feelings. Thanks for the list.