### PR TITLE
Add Wachd — self-hosted on-call alerting with AI root cause analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [Thruk](https://www.thruk.org/) - Multibackend monitoring web interface with support for Naemon, Nagios, Icinga and Shinken. ([Source Code](https://github.com/sni/Thruk)) `GPL-1.0` `Perl`
 - [tirreno](https://www.tirreno.com/) - Application-level security to protect your app from threats, fraud, and abuse. ([Demo](https://play.tirreno.com/), [Source Code](https://github.com/tirrenotechnologies/tirreno)) `AGPL-3.0` `PHP/Docker`
 - [Uptime Kuma](https://uptime.kuma.pet/) - Modern, self-hosted monitoring tool with a clean UI and rich notification support. ([Source Code](https://github.com/louislam/uptime-kuma)) `MIT` `Nodejs`
+- [Wachd](https://wachd.io/) - Self-hosted on-call alerting with AI-powered root cause analysis for DevOps teams. Receives alerts from Grafana, Datadog, and Prometheus. ([Source Code](https://github.com/wachd/wachd)) `Apache-2.0` `Go/Docker/K8S`
 - [Wazuh](https://wazuh.com/) - Unified XDR and SIEM protection for endpoints and cloud workloads. ([Source Code](https://github.com/wazuh/wazuh)) `GPL-2.0` `C`
 - [Zabbix](https://www.zabbix.com/) - Enterprise-class software for monitoring of networks and applications. ([Source Code](https://git.zabbix.com/projects/ZBX/repos/zabbix/browse)) `GPL-2.0` `C`
 


### PR DESCRIPTION
## Description

Adding [Wachd](https://wachd.io/) to the Monitoring & Status Pages section.

**What it is:** Self-hosted on-call alerting platform with AI-powered root cause analysis. When an alert fires from Grafana, Datadog, or Prometheus, Wachd automatically collects context (recent commits, error logs, metrics), runs AI correlation, and routes the diagnosis to the on-call engineer.

**Checklist:**
- [x] Entry is alphabetically sorted (between Uptime Kuma and Wazuh)
- [x] License: Apache-2.0
- [x] Language tags: Go/Docker/K8S
- [x] Source code link included
- [x] Description is concise and accurate
- [x] Project is actively maintained