### PR TITLE
Add Monoscope to Log Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Log management tools: collect, parse, visualize...
 - [Flume](https://flume.apache.org/) - Distributed, reliable, and available service for efficiently collecting, aggregating, and moving large amounts of log data. ([Source Code](https://github.com/apache/flume)) `Apache-2.0` `Java`
 - [GoAccess](https://goaccess.io/) - Real-time web log analyzer and interactive viewer that runs in a terminal or through the browser. ([Source Code](https://github.com/allinurl/goaccess)) `MIT` `C`
 - [Loki](https://grafana.com/oss/loki/) - Log aggregation system designed to store and query logs from all your applications and infrastructure. ([Source Code](https://github.com/grafana/loki)) `AGPL-3.0` `Go`
+- [Monoscope](https://monoscope.tech/) - Ingest, store and query logs, traces and metrics using S3-compatible buckets, with natural language queries via LLMs. ([Source Code](https://github.com/monoscope-tech/monoscope)) `AGPL-3.0` `Haskell`
 - [reaction](https://reaction.ppom.me/) - A lightweight daemon that scans program outputs for repeated patterns, and takes action. ([Source Code](https://framagit.org/ppom/reaction)) `AGPL-3.0` `Rust`
 - [rsyslog](https://www.rsyslog.com/) - Rocket-fast system for log processing. ([Source Code](https://github.com/rsyslog/rsyslog)) `GPL-3.0` `C`
 


### PR DESCRIPTION
## Add Monoscope to Log Management

[Monoscope](https://github.com/monoscope-tech/monoscope) is an open-source observability platform (AGPL-3.0) that ingests logs, traces, and metrics and stores them in S3-compatible buckets. It supports natural language queries via LLMs and is OpenTelemetry-native with 750+ integrations.

- Website: https://monoscope.tech
- License: AGPL-3.0
- Language: Haskell