### PR TITLE
Add Linuxfabrik Kickstart to Deployment Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Tools and scripts to support deployments to your servers.
 - [Fabric](https://www.fabfile.org/) - Python library and cli tool for streamlining the use of SSH for application deployment or systems administration tasks. ([Source Code](https://github.com/fabric/fabric)) `BSD-2-Clause` `Python`
 - [FaynoSync](https://faynosync.com) - Self-hosted Dynamic Update Server with statistics, supporting multiple updaters. Flexible features for seamless app updates and insights.  ([Source Code](https://github.com/ku9nov/faynoSync), [Clients](https://github.com/ku9nov/faynoSync-dashboard)) `Apache-2.0` `Docker/Go`
 - [Genesis](https://github.com/genesis-community/genesis) - A template framework for multi-environment BOSH deployments. `MIT` `Perl`
+- [Linuxfabrik Kickstart](https://github.com/Linuxfabrik/kickstart) - Generic Kickstart (RHEL/Fedora), Preseed (Debian) and Autoinstall (Ubuntu) configurations with BIOS/UEFI, four install profiles (minimal/CIS/cloud/cloud-CIS), LVM and SELinux enforcing. `Unlicense` `Shell`
 - [munki](https://www.munki.org/munki/) - Webserver-based repository of packages and package metadata, that allows macOS administrators to manage software installs. ([Source Code](https://github.com/munki/munki)) `Apache-2.0` `Python`
 - [Overcast](https://andrewchilds.github.io/overcast/) - Deploy VMs across different cloud providers, and run commands and scripts across any or all of them in parallel via SSH. ([Source Code](https://github.com/andrewchilds/overcast)) `MIT` `Nodejs`
 


### PR DESCRIPTION
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software)
- [x] Software you are submitting is not your own, unless you have a healthy ecosystem with a few contributors
- [x] Submit one item per pull request.
- [x] Format your submission as follows
- [x] Additions are inserted preserving alphabetical order.
- [x] Additions are not already listed at [awesome-selfhosted](https://awesome-selfhosted.net)
- [x] The `Language` tag is the main **server-side** requirement for the software.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software project you are adding to the list is actively maintained.
- [x] The pull request title is informative.

- **Why is it awesome?**

Generic, hosted Kickstart (RHEL 8+, Fedora 38+ and compatible), Preseed (Debian 11+) and Autoinstall (Ubuntu 20.04+) configurations. Supports BIOS and UEFI, automatic disk detection, four install profiles (minimal, CIS, cloud, cloud-CIS), LVM, SELinux enforcing, locked root, and a `LF_KICKSTART_VERSION` build stamp persisted on the installed system for fleet identification across distros. Public-domain (Unlicense).

- **Have you used it? For how long?**

This is Linuxfabrik's own software, submitted under the "healthy ecosystem" clause. The kickstart, preseed and autoinstall configurations have been developed and maintained by Linuxfabrik since 2017 and provision every Linux host across our own and customer fleets.