### PR TITLE
Add FirewallFabrik to Network Configuration Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 
 Network configuration management tools.
 
+- [FirewallFabrik](https://linuxfabrik.github.io/firewallfabrik/) - Modern [Firewall Builder](https://github.com/fwbuilder/fwbuilder) successor. Qt-based GUI for managing iptables and nftables policies across many hosts from a centralized policy database; generates deployment-ready shell scripts. ([Source Code](https://github.com/Linuxfabrik/firewallfabrik)) `GPL-2.0` `Python`
 - [GNS3](https://www.gns3.com/) - Graphical network simulator that provides a variety of virtual appliances. ([Source Code](https://github.com/GNS3/gns3-gui/)) `GPL-3.0` `Python`
 - [OpenWISP](https://openwisp.org/) - Open Source Network Management System for OpenWRT based routers and access points. ([Demo](https://openwisp.org/demo.html), [Source Code](https://github.com/openwisp)) `GPL-3.0` `Python`
 - [Oxidized](https://github.com/ytti/oxidized) - Network device configuration backup tool. `Apache-2.0` `Ruby`


### PR DESCRIPTION
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software)
- [x] Software you are submitting is not your own, unless you have a healthy ecosystem with a few contributors
- [x] Submit one item per pull request.
- [x] Format your submission as follows
- [x] Additions are inserted preserving alphabetical order.
- [x] Additions are not already listed at [awesome-selfhosted](https://awesome-selfhosted.net)
- [x] The `Language` tag is the main **server-side** requirement for the software.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software project you are adding to the list is actively maintained.
- [x] The pull request title is informative.

- **Why is it awesome?**

Modern successor to Firewall Builder (fwbuilder). Qt-based GUI that manages iptables and nftables policies for many devices from a single policy database with reusable objects (services, networks, rule sets). Scales from a handful of devices to hundreds of firewalls and generates deployment-ready shell scripts per platform. Distributed on PyPI (`firewallfabrik`), GPL-2.0-or-later.

- **Have you used it? For how long?**

This is Linuxfabrik's own software, submitted under the "healthy ecosystem" clause. FirewallFabrik is developed by Linuxfabrik as the modern successor to Firewall Builder and is in active use to generate firewall policies on our own and customer Linux fleets. Early community feedback from former Firewall Builder users is captured in the README.

Note: I placed this in `Network Configuration Management` since the other host firewall management tools live there (closest neighbour). If you would prefer a new `Firewall` subsection or move it to `Security` or another section, happy to follow your call.