### PR TITLE
Add Meridian NIP under Network Configuration Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 Network configuration management tools.
 
 - [GNS3](https://www.gns3.com/) - Graphical network simulator that provides a variety of virtual appliances. ([Source Code](https://github.com/GNS3/gns3-gui/)) `GPL-3.0` `Python`
+- [Meridian NIP](https://meridiannip.com) - Self-hosted DNS / DHCP / IPAM portal with built-in network diagnostics, monitoring, certificate lifecycle, runbooks, and threat intel behind one MFA-gated portal. Reads from Infoblox / NetBox / phpIPAM / BlueCat / ISC Kea / LDAP / Entra. ([Source Code](https://github.com/MeridianNIP/meridian)) `Apache-2.0` `Python`
 - [OpenWISP](https://openwisp.org/) - Open Source Network Management System for OpenWRT based routers and access points. ([Demo](https://openwisp.org/demo.html), [Source Code](https://github.com/openwisp)) `GPL-3.0` `Python`
 - [Oxidized](https://github.com/ytti/oxidized) - Network device configuration backup tool. `Apache-2.0` `Ruby`
 - [phpIPAM](https://phpipam.net/) - Open source IP address management with PowerDNS integration. ([Source Code](https://github.com/phpipam/phpipam)) `GPL-3.0` `PHP`


### PR DESCRIPTION
Adds [Meridian NIP](https://github.com/MeridianNIP/meridian), an Apache 2.0 self-hosted DNS / DHCP / IPAM + network-operations portal — first public release v1.0.0 / v1.0.1 on 2026-05-14.

Slots in alphabetically under **Network Configuration Management** between GNS3 and OpenWISP, alongside Oxidized, phpIPAM, RANCID, and rConfig.

What it is:
- Reader + tooling surface over Infoblox / NetBox / phpIPAM / BlueCat / ISC Kea / LDAP / Entra
- Network tools: ping, traceroute / MTR, port scan, packet capture, SNMP walk, ASN, BGP looking glass, IP reputation (8 DNSBLs), HTTP security-header audit, subnet calculator
- DNS tools: dig + propagation, DNSSEC chain, zone health, WHOIS (single + bulk), CT logs / crt.sh, AXFR, typosquat, SPF/DKIM/DMARC
- Monitors (HTTP/TCP/ICMP/cert/DNS, hard-capped to 30s floor)
- Certificate portfolio + expiry sweep
- Device config backup (Cisco / Juniper / Arista / PAN-OS / FortiOS / MikroTik / generic SSH)
- Behind argon2id + TOTP MFA + single-session + HMAC audit chain + fail2ban + AppArmor

Code: <https://github.com/MeridianNIP/meridian>  
Site: <https://meridiannip.com>  
Apt: <https://meridiannip.com/apt>