### PR TITLE
Add KKTerm to Remote Desktop Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ _See also: [Cloud Native Landscape - Streaming & Messaging](https://landscape.cn
 
 _See also: [awesome-selfhosted/Remote Access](https://awesome-selfhosted.net/tags/remote-access.html)_
 
+- [KKTerm](https://ryantsai.github.io/KKTerm/) - Windows-first terminal workspace for SSH, SFTP, RDP, and VNC. ([Source Code](https://github.com/ryantsai/KKTerm)) `MIT` `Rust`
 - [Remmina](https://www.remmina.org/) - Feature-rich remote desktop application for linux and other unixes. ([Source Code](https://gitlab.com/Remmina/Remmina)) `GPL-2.0` `C`
 - [Tiger VNC](https://tigervnc.org/) - High-performance, multi-platform VNC client and server. ([Source Code](https://github.com/TigerVNC/tigervnc)) `GPL-2.0` `C++`
 - [X2go](https://wiki.x2go.org/doku.php) - X2Go is an open source remote desktop software for Linux that uses the NoMachine/NX technology protocol. ([Source Code](https://code.x2go.org/gitweb)) `GPL-2.0` `Perl`


### PR DESCRIPTION
Adds KKTerm to the Remote Desktop Clients section.\n\n- Windows-first terminal workspace\n- SSH, SFTP, RDP, and VNC support\n- Open source Tauri app