### PR TITLE
Add vps-healthcheck to Monitoring & Status Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ _Related: [Metrics & Metric Collection](#metrics--metric-collection)_
 - [Thruk](https://www.thruk.org/) - Multibackend monitoring web interface with support for Naemon, Nagios, Icinga and Shinken. ([Source Code](https://github.com/sni/Thruk)) `GPL-1.0` `Perl`
 - [tirreno](https://www.tirreno.com/) - Application-level security to protect your app from threats, fraud, and abuse. ([Demo](https://play.tirreno.com/), [Source Code](https://github.com/tirrenotechnologies/tirreno)) `AGPL-3.0` `PHP/Docker`
 - [Uptime Kuma](https://uptime.kuma.pet/) - Modern, self-hosted monitoring tool with a clean UI and rich notification support. ([Source Code](https://github.com/louislam/uptime-kuma)) `MIT` `Nodejs`
+- [vps-healthcheck](https://github.com/cipherfoxie/vps-healthcheck) - Daily SSH-based VPS audit: twelve checks bundled into one SSH session, single notification push on regression, exit 0/1/2 for cron. ~250 lines of bash, no daemon. `MIT` `Shell`
 - [Wazuh](https://wazuh.com/) - Unified XDR and SIEM protection for endpoints and cloud workloads. ([Source Code](https://github.com/wazuh/wazuh)) `GPL-2.0` `C`
 - [Zabbix](https://www.zabbix.com/) - Enterprise-class software for monitoring of networks and applications. ([Source Code](https://git.zabbix.com/projects/ZBX/repos/zabbix/browse)) `GPL-2.0` `C`
 


### PR DESCRIPTION
[vps-healthcheck](https://github.com/cipherfoxie/vps-healthcheck) is a single bash script that runs twelve daily health checks against a remote VPS over SSH, bundled into one SSH session, with one notification push on regression and exit codes 0/1/2 for cron.

Designed for self-hosted operators with one or two VPSes where running a full observability stack (Prometheus + Alertmanager + Grafana) is overkill. Reference deployment runs daily against [sovgrid.org](https://sovgrid.org/projects/).

**Checks:** SSH reachability, public URL 200, pending Debian-Security updates, failed systemd units, UFW, fail2ban bans, disk usage, memory, OOM kills in `journalctl -k`, Let's Encrypt cert expiry, expected docker containers up, optional freshness file.

**Format compliance:**
- MIT license, source on GitHub
- Alphabetical placement: after "Uptime Kuma", before "Wazuh"
- One-line entry per CONTRIBUTING convention with `MIT` `Shell` tags
- Active project (last push 2026-05-20), single-author, single dependency (`bash` + `ssh`)