### PR TITLE
Add PikoCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ _Related: [IT Asset Management](#it-asset-management)_
 - [Jenkins](https://jenkins-ci.org/) - Continuous Integration Server. ([Source Code](https://github.com/jenkinsci/jenkins/)) `MIT` `Java`
 - [Laminar](https://laminar.ohwg.net) - Fast, lightweight, simple and flexible Continuous Integration. ([Source Code](https://github.com/ohwgiles/laminar)) `GPL-3.0` `C++`
 - [PHP Censor](https://github.com/php-censor/php-censor) - Open source self-hosted continuous integration server for PHP projects. `BSD-2-Clause` `PHP`
+- [PikoCI](https://pikoci.com) - Self-hosted CI/CD inspired by Concourse. Single binary, any database, any queue. HCL pipelines, pluggable runners and resource types. ([Source Code](https://github.com/pikoci/pikoci)) `Apache-2.0` `Go`
 - [Strider](https://strider-cd.github.io/) - Open Source Continuous Deployment / Continuous Integration platform. ([Source Code](https://github.com/Strider-CD/strider)) `MIT` `Nodejs`
 - [Terrateam](https://terrateam.io) - GitOps-first automation platform for Terraform and OpenTofu workflows with support for self-hosted runners. ([Source Code](https://github.com/terrateamio/terrateam)) `MPL-2.0` `OCaml/Docker`
 - [werf](https://werf.io/) - Open Source CI/CD tool for building Docker images and deploying to Kubernetes via GitOps. ([Source Code](https://github.com/werf/werf)) `Apache-2.0` `Go`


### PR DESCRIPTION
PikoCI is a self-hosted CI/CD system inspired by Concourse CI. 
Runs as a single binary with no external dependencies required. 
Pluggable database (SQLite, PostgreSQL, MySQL) and queue backends (NATS, Kafka, RabbitMQ).
HCL pipelines, pluggable resource types, runners, service types, and secret backends.
Apache 2.0 licensed.

- Website: https://pikoci.com
- GitHub: https://github.com/pikoci/pikoci